### PR TITLE
add unsupported notification for ie and edge

### DIFF
--- a/app/assets/index.hbs
+++ b/app/assets/index.hbs
@@ -1,11 +1,12 @@
 <!doctype html>
 <html>
+
 <head>
     {{#if INCLUDE_BASE}}
     <base href="/">
     {{/if}}
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width"/>
+    <meta name="viewport" content="width=device-width" />
     <meta name="format-detection" content="telephone=no">
     <title>{{title}}</title>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; worker-src 'self' blob:; script-src https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/ 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' *; font-src 'self' data: https://at.alicdn.com; img-src 'self' data:;">
@@ -14,35 +15,223 @@
         body {
             background-color: #2a2a2a;
         }
+
         .centerDiv {
-            width:140px; border-radius: 5px; color:lightgrey;
-            padding:10px; height:50px; position:absolute;
-            margin-top:-25px; margin-left:-70px; top:50%; left:50%;
+            width: 140px;
+            border-radius: 5px;
+            color: lightgrey;
+            padding: 10px;
+            height: 50px;
+            position: absolute;
+            margin-top: -25px;
+            margin-left: -70px;
+            top: 50%;
+            left: 50%;
             font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
             font-weight: 100;
             font-size: 44px;
         }
+
+        .outdated-browser {
+            margin-top: 150px;
+            position: relative;
+            background-color: #fff;
+            border: 0;
+            border-radius: 0;
+            background-clip: padding-box;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, .15);
+            max-width: 520px;
+            margin: 100px auto 0;
+            font-family: Roboto Medium, Monospaced Number, Chinese Quote, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, PingFang SC, Hiragino Sans GB, Microsoft YaHei, Helvetica Neue, Helvetica, Arial, sans-serif;
+            font-size: 16px;
+            font-variant: tabular-nums;
+            line-height: 1.5;
+            color: #2a2a2a;
+            box-sizing: border-box;
+            opacity: 1;
+            transition: all .3s cubic-bezier(.645, .045, .355, 1);
+        }
+
+        .outdated-browser.hidden {
+            opacity: 0;
+            visibility: hidden;
+        }
+
+        .outdated-browser__header {
+            background: #fff;
+            border-bottom: 1px solid #eee;
+            padding: 16px 24px;
+            font-weight: 700;
+            position: relative;
+        }
+
+        .outdated-browser__close {
+            display: block;
+            font-size: 36px;
+            line-height: 36px;
+            position: relative;
+            text-decoration: none;
+            color: #00a9e0;
+            transition: all .3s cubic-bezier(.645, .045, .355, 1);
+            cursor: pointer;
+            position: absolute;
+            right: 24px;
+            top: 10px;
+            font-weight: 500;
+        }
+
+        .outdated-browser__close:hover {
+            color: #26c2ed;
+        }
+
+        .outdated-browser__body {
+            padding: 24px;
+        }
+
+        .outdated-browser__footer {
+            border-top: 1px solid #eee;
+            padding: 16px 24px;
+            text-align: right;
+        }
+
+        .outdated-browser__link-wrapper {
+            padding: 24px 0;
+        }
+
+        .outdated-browser__body a {
+            display: inline-block;
+            color: #00a9e0;
+            text-decoration: none;
+        }
+
+        .outdated-browser__body a:hover {
+            color: #00a9e0;
+            transition: all .3s cubic-bezier(.645, .045, .355, 1);
+        }
+
+        .outdated-browser__btn {
+            outline: none;
+            line-height: 1.5;
+            display: inline-block;
+            font-weight: 400;
+            text-align: center;
+            touch-action: manipulation;
+            cursor: pointer;
+            background-image: none;
+            border: 1px solid transparent;
+            white-space: nowrap;
+            padding: 0 28px;
+            font-size: 14px;
+            border-radius: 0;
+            height: 32px;
+            user-select: none;
+            transition: all .3s cubic-bezier(.645, .045, .355, 1);
+            box-shadow: 0 2px 0 rgba(0, 0, 0, .015);
+            color: #00a9e0;
+            background-color: transparent;
+            border-color: #00a9e0;
+        }
+
+        .outdated-browser__btn:hover {
+            color: #26c2ed;
+            border-color: #26c2ed;
+        }
     </style>
     {{#if ELECTRON}}
-        <script>
-            var ref = encodeURIComponent(document.referrer);
-            if (window.process && window.process.versions && window.process.versions['electron']) {
-                window.electron = window.process.versions['electron'];
-                window.remote = require('electron').remote;
-                window._$guid$_ = window.remote.getGlobal('guid');
-                window.app_version = window.remote.getGlobal('version');
-                ref = 'lw-' + window.process.platform + '-' + window.app_version + '-' + window.remote.getGlobal('guid');
-                window.onload = function(e){
-                    var content = document.getElementById("content");
-                    if (content) content.className = "electron " + window.process.platform;
-                }
+    <script>
+        var ref = encodeURIComponent(document.referrer);
+        if (window.process && window.process.versions && window.process.versions['electron']) {
+            window.electron = window.process.versions['electron'];
+            window.remote = require('electron').remote;
+            window._$guid$_ = window.remote.getGlobal('guid');
+            window.app_version = window.remote.getGlobal('version');
+            ref = 'lw-' + window.process.platform + '-' + window.app_version + '-' + window.remote.getGlobal('guid');
+            window.onload = function (e) {
+                var content = document.getElementById("content");
+                if (content) content.className = "electron " + window.process.platform;
             }
-        </script>
+        }
+    </script>
     {{/if}}
 </head>
+
 <body>
     <main id="content">
         <h1 class="centerDiv" style="">Loading...</h1>
     </main>
+    <script>
+        function ieVersion(uaString) {
+            uaString = uaString || navigator.userAgent;
+            var match = /\b(MSIE |Trident.*?rv:|Edge\/)(\d+)/.exec(uaString);
+            if (match) return parseInt(match[2])
+        }
+
+        function renderOutdatedWarning() {
+            var container = document.createElement("div");
+            var header = document.createElement("div");
+            var body = document.createElement("div");
+            var footer = document.createElement("div");
+            var linkWrapper = document.createElement("div");
+            var link = document.createElement("a");
+            var closeLink = document.createElement("span");
+            var btn = document.createElement("button");
+
+            var headerText = document.createTextNode("Unsupported browser");
+            var bodyText = document.createTextNode("The Browser you are using has not been fully tested to support the BitShares Wallet. We highly recommend that you backup your local wallet and import it using the Chrome Browser until we have had more time to fully test your browser of choice.Use at your own risk.");
+            var linkText = document.createTextNode("Google Chrome");
+            var closeLinkText = document.createTextNode("×");
+            var btnText = document.createTextNode("I UNDERSTAND");
+
+            linkWrapper.classList.add("outdated-browser__link-wrapper");
+            link.appendChild(linkText);
+            link.setAttribute("href", "https://www.google.com/chrome/browser/desktop/");
+            link.setAttribute("target", "_blank");
+            linkWrapper.appendChild(link);
+
+            closeLink.classList.add("outdated-browser__close");
+            closeLink.appendChild(closeLinkText);
+
+
+            container.classList.add("outdated-browser");
+            header.appendChild(headerText);
+            header.appendChild(closeLink);
+            header.classList.add("outdated-browser__header");
+
+            body.appendChild(bodyText);
+            body.classList.add("outdated-browser__body");
+            body.appendChild(linkWrapper);
+
+
+            btn.classList.add("outdated-browser__btn");
+            btn.appendChild(btnText);
+
+            footer.classList.add("outdated-browser__footer");
+            footer.appendChild(btn);
+
+
+            container.appendChild(header);
+            container.appendChild(body);
+            container.appendChild(footer);
+
+            document.getElementById("content").appendChild(container);
+        }
+
+        if (ieVersion()) {
+            renderOutdatedWarning();
+            document.getElementById("content").removeChild(document.querySelector(".centerDiv"));
+
+            var closeBtn = document.querySelector(".outdated-browser__close");
+            var okBtn = document.querySelector(".outdated-browser__btn");
+            var container = document.querySelector(".outdated-browser");
+            closeBtn.addEventListener("click", function () {
+                container.classList.add("hidden");
+            });
+
+            okBtn.addEventListener("click", function () {
+                container.classList.add("hidden");
+            });
+        }
+    </script>
 </body>
+
 </html>

--- a/app/assets/index.hbs
+++ b/app/assets/index.hbs
@@ -11,22 +11,6 @@
     <title>{{title}}</title>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; worker-src 'self' blob:; script-src https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/ 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' *; font-src 'self' data: https://at.alicdn.com; img-src 'self' data:;">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    {{#if ELECTRON}}
-    <script>
-        var ref = encodeURIComponent(document.referrer);
-        if (window.process && window.process.versions && window.process.versions['electron']) {
-            window.electron = window.process.versions['electron'];
-            window.remote = require('electron').remote;
-            window._$guid$_ = window.remote.getGlobal('guid');
-            window.app_version = window.remote.getGlobal('version');
-            ref = 'lw-' + window.process.platform + '-' + window.app_version + '-' + window.remote.getGlobal('guid');
-            window.onload = function (e) {
-                var content = document.getElementById("content");
-                if (content) content.className = "electron " + window.process.platform;
-            }
-        }
-    </script>
-    {{/if}}
     <style>
         body {
             background-color: #2a2a2a;
@@ -44,11 +28,27 @@
             top: 50%;
             left: 50%;
             font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue",
-                Helvetica, Arial, "Lucida Grande", sans-serif;
+            Helvetica, Arial, "Lucida Grande", sans-serif;
             font-weight: 100;
             font-size: 44px;
         }
     </style>
+    {{#if ELECTRON}}
+    <script>
+        var ref = encodeURIComponent(document.referrer);
+        if (window.process && window.process.versions && window.process.versions['electron']) {
+            window.electron = window.process.versions['electron'];
+            window.remote = require('electron').remote;
+            window._$guid$_ = window.remote.getGlobal('guid');
+            window.app_version = window.remote.getGlobal('version');
+            ref = 'lw-' + window.process.platform + '-' + window.app_version + '-' + window.remote.getGlobal('guid');
+            window.onload = function (e) {
+                var content = document.getElementById("content");
+                if (content) content.className = "electron " + window.process.platform;
+            }
+        }
+    </script>
+    {{/if}}
 </head>
 
 <body>
@@ -80,7 +80,7 @@
             var btn = document.createElement("button");
 
             var headerText = document.createTextNode("Unsupported browser");
-            var bodyText = document.createTextNode("The Browser you are using has not been fully tested to support the BitShares Wallet. We highly recommend that you backup your local wallet and import it using the Chrome Browser until we have had more time to fully test your browser of choice.Use at your own risk.");
+            var bodyText = document.createTextNode("The Browser you are using has not been fully tested to support the BitShares Wallet. We highly recommend that you backup your local wallet and import it using the Chrome Browser.");
             var linkText = document.createTextNode("Google Chrome");
             var closeLinkText = document.createTextNode("×");
             var btnText = document.createTextNode("I UNDERSTAND");

--- a/app/assets/index.hbs
+++ b/app/assets/index.hbs
@@ -11,132 +11,6 @@
     <title>{{title}}</title>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; worker-src 'self' blob:; script-src https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/ 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' *; font-src 'self' data: https://at.alicdn.com; img-src 'self' data:;">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <style>
-        body {
-            background-color: #2a2a2a;
-        }
-
-        .centerDiv {
-            width: 140px;
-            border-radius: 5px;
-            color: lightgrey;
-            padding: 10px;
-            height: 50px;
-            position: absolute;
-            margin-top: -25px;
-            margin-left: -70px;
-            top: 50%;
-            left: 50%;
-            font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-            font-weight: 100;
-            font-size: 44px;
-        }
-
-        .outdated-browser {
-            margin-top: 150px;
-            position: relative;
-            background-color: #fff;
-            border: 0;
-            border-radius: 0;
-            background-clip: padding-box;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, .15);
-            max-width: 520px;
-            margin: 100px auto 0;
-            font-family: Roboto Medium, Monospaced Number, Chinese Quote, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, PingFang SC, Hiragino Sans GB, Microsoft YaHei, Helvetica Neue, Helvetica, Arial, sans-serif;
-            font-size: 16px;
-            font-variant: tabular-nums;
-            line-height: 1.5;
-            color: #2a2a2a;
-            box-sizing: border-box;
-            opacity: 1;
-            transition: all .3s cubic-bezier(.645, .045, .355, 1);
-        }
-
-        .outdated-browser.hidden {
-            opacity: 0;
-            visibility: hidden;
-        }
-
-        .outdated-browser__header {
-            background: #fff;
-            border-bottom: 1px solid #eee;
-            padding: 16px 24px;
-            font-weight: 700;
-            position: relative;
-        }
-
-        .outdated-browser__close {
-            display: block;
-            font-size: 36px;
-            line-height: 36px;
-            position: relative;
-            text-decoration: none;
-            color: #00a9e0;
-            transition: all .3s cubic-bezier(.645, .045, .355, 1);
-            cursor: pointer;
-            position: absolute;
-            right: 24px;
-            top: 10px;
-            font-weight: 500;
-        }
-
-        .outdated-browser__close:hover {
-            color: #26c2ed;
-        }
-
-        .outdated-browser__body {
-            padding: 24px;
-        }
-
-        .outdated-browser__footer {
-            border-top: 1px solid #eee;
-            padding: 16px 24px;
-            text-align: right;
-        }
-
-        .outdated-browser__link-wrapper {
-            padding: 24px 0;
-        }
-
-        .outdated-browser__body a {
-            display: inline-block;
-            color: #00a9e0;
-            text-decoration: none;
-        }
-
-        .outdated-browser__body a:hover {
-            color: #00a9e0;
-            transition: all .3s cubic-bezier(.645, .045, .355, 1);
-        }
-
-        .outdated-browser__btn {
-            outline: none;
-            line-height: 1.5;
-            display: inline-block;
-            font-weight: 400;
-            text-align: center;
-            touch-action: manipulation;
-            cursor: pointer;
-            background-image: none;
-            border: 1px solid transparent;
-            white-space: nowrap;
-            padding: 0 28px;
-            font-size: 14px;
-            border-radius: 0;
-            height: 32px;
-            user-select: none;
-            transition: all .3s cubic-bezier(.645, .045, .355, 1);
-            box-shadow: 0 2px 0 rgba(0, 0, 0, .015);
-            color: #00a9e0;
-            background-color: transparent;
-            border-color: #00a9e0;
-        }
-
-        .outdated-browser__btn:hover {
-            color: #26c2ed;
-            border-color: #26c2ed;
-        }
-    </style>
     {{#if ELECTRON}}
     <script>
         var ref = encodeURIComponent(document.referrer);
@@ -153,6 +27,28 @@
         }
     </script>
     {{/if}}
+    <style>
+        body {
+            background-color: #2a2a2a;
+        }
+
+        .centerDiv {
+            width: 140px;
+            border-radius: 5px;
+            color: lightgrey;
+            padding: 10px;
+            height: 50px;
+            position: absolute;
+            margin-top: -25px;
+            margin-left: -70px;
+            top: 50%;
+            left: 50%;
+            font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue",
+                Helvetica, Arial, "Lucida Grande", sans-serif;
+            font-weight: 100;
+            font-size: 44px;
+        }
+    </style>
 </head>
 
 <body>
@@ -165,8 +61,15 @@
             var match = /\b(MSIE |Trident.*?rv:|Edge\/)(\d+)/.exec(uaString);
             if (match) return parseInt(match[2])
         }
-
+        function createLinkTag() {
+            var link = document.createElement("link");
+            link.href = "outdated_browser.css";
+            link.type = "text/css";
+            link.rel = "stylesheet";
+            document.getElementsByTagName("head")[0].appendChild(link);
+        }
         function renderOutdatedWarning() {
+            createLinkTag();
             var container = document.createElement("div");
             var header = document.createElement("div");
             var body = document.createElement("div");

--- a/app/assets/outdated_browser.css
+++ b/app/assets/outdated_browser.css
@@ -1,0 +1,106 @@
+.outdated-browser {
+    margin-top: 150px;
+    position: relative;
+    background-color: #fff;
+    border: 0;
+    border-radius: 0;
+    background-clip: padding-box;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    max-width: 520px;
+    margin: 100px auto 0;
+    font-family: Roboto Medium, Monospaced Number, Chinese Quote, -apple-system,
+        BlinkMacSystemFont, Segoe UI, Roboto, PingFang SC, Hiragino Sans GB,
+        Microsoft YaHei, Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    font-variant: tabular-nums;
+    line-height: 1.5;
+    color: #2a2a2a;
+    box-sizing: border-box;
+    opacity: 1;
+    transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+.outdated-browser.hidden {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.outdated-browser__header {
+    background: #fff;
+    border-bottom: 1px solid #eee;
+    padding: 16px 24px;
+    font-weight: 700;
+    position: relative;
+}
+
+.outdated-browser__close {
+    display: block;
+    font-size: 36px;
+    line-height: 36px;
+    position: relative;
+    text-decoration: none;
+    color: #00a9e0;
+    transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+    cursor: pointer;
+    position: absolute;
+    right: 24px;
+    top: 10px;
+    font-weight: 500;
+}
+
+.outdated-browser__close:hover {
+    color: #26c2ed;
+}
+
+.outdated-browser__body {
+    padding: 24px;
+}
+
+.outdated-browser__footer {
+    border-top: 1px solid #eee;
+    padding: 16px 24px;
+    text-align: right;
+}
+
+.outdated-browser__link-wrapper {
+    padding: 24px 0;
+}
+
+.outdated-browser__body a {
+    display: inline-block;
+    color: #00a9e0;
+    text-decoration: none;
+}
+
+.outdated-browser__body a:hover {
+    color: #00a9e0;
+    transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+.outdated-browser__btn {
+    outline: none;
+    line-height: 1.5;
+    display: inline-block;
+    font-weight: 400;
+    text-align: center;
+    touch-action: manipulation;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    padding: 0 28px;
+    font-size: 14px;
+    border-radius: 0;
+    height: 32px;
+    user-select: none;
+    transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.015);
+    color: #00a9e0;
+    background-color: transparent;
+    border-color: #00a9e0;
+}
+
+.outdated-browser__btn:hover {
+    color: #26c2ed;
+    border-color: #26c2ed;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,6 @@ module.exports = function(env) {
         regexString = regexString + (l + (i < locales.length - 1 ? "|" : ""));
     });
     const localeRegex = new RegExp(regexString);
-
     var plugins = [
         new HtmlWebpackPlugin({
             template: "!!handlebars-loader!app/assets/index.hbs",
@@ -77,6 +76,7 @@ module.exports = function(env) {
                 ELECTRON: !!env.electron
             }
         }),
+
         new webpack.DefinePlugin({
             APP_VERSION: JSON.stringify(__VERSION__),
             __ELECTRON__: !!env.electron,
@@ -188,6 +188,16 @@ module.exports = function(env) {
                         "dictionary_en.json"
                     ),
                     to: path.join(outputPath, "dictionary.json"),
+                    toType: "file"
+                },
+                {
+                    from: path.join(
+                        root_dir,
+                        "app",
+                        "assets",
+                        "outdated_browser.css"
+                    ),
+                    to: path.join(outputPath, "outdated_browser.css"),
                     toType: "file"
                 }
             ],


### PR DESCRIPTION
Hello, @sschiessl-bcp. 
Unfortunately, UI crashes before it can render anything. 
So, I created custom html layout and css styles for notification, and render it via js.
I have tried to make it similar to https://github.com/bitshares/bitshares-ui/issues/2175#issuecomment-447593135 design, only in light colors. Because on dark overlay, dark notification is difficult to spot.