### PR TITLE
116 tabs refactoring

### DIFF
--- a/app/App.jsx
+++ b/app/App.jsx
@@ -46,6 +46,12 @@ const AccountPage = Loadable({
     loading: LoadingIndicator
 });
 
+const AccountVotingPage = Loadable({
+    loader: () =>
+        import(/* webpackChunkName: "account" */ "./components/Account/AccountVoting"),
+    loading: LoadingIndicator
+});
+
 const Transfer = Loadable({
     loader: () =>
         import(/* webpackChunkName: "transfer" */ "./components/Transfer/Transfer"),

--- a/app/App.jsx
+++ b/app/App.jsx
@@ -46,12 +46,6 @@ const AccountPage = Loadable({
     loading: LoadingIndicator
 });
 
-const AccountVotingPage = Loadable({
-    loader: () =>
-        import(/* webpackChunkName: "account" */ "./components/Account/AccountVoting"),
-    loading: LoadingIndicator
-});
-
 const Transfer = Loadable({
     loader: () =>
         import(/* webpackChunkName: "transfer" */ "./components/Transfer/Transfer"),

--- a/app/assets/stylesheets/components/_account.scss
+++ b/app/assets/stylesheets/components/_account.scss
@@ -270,6 +270,8 @@ div.header-selector {
             margin-right: 10px;
         }
     }
+
+    margin-bottom: 14px;
 }
 
 div.account-tabs {

--- a/app/components/Account/AccountPage.jsx
+++ b/app/components/Account/AccountPage.jsx
@@ -140,8 +140,7 @@ class AccountPage extends React.Component {
                             )}
                         />
                         <Route
-                            path={`/account/${account_name}/voting`}
-                            exact
+                            path={`/account/${account_name}/voting/:tab`}
                             render={() => <AccountVoting {...passOnProps} />}
                         />
                         <Route

--- a/app/components/Account/AccountPage.jsx
+++ b/app/components/Account/AccountPage.jsx
@@ -143,6 +143,10 @@ class AccountPage extends React.Component {
                             path={`/account/${account_name}/voting/:tab`}
                             render={() => <AccountVoting {...passOnProps} />}
                         />
+                        <Redirect
+                            from={`/account/${account_name}/voting`}
+                            to={`/account/${account_name}/voting/witnesses`}
+                        />
                         <Route
                             path={`/account/${account_name}/whitelist`}
                             exact

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -772,275 +772,275 @@ class AccountVoting extends React.Component {
                             actionButtons={saveText}
                             tabsClass="account-overview no-padding bordered-header content-block"
                         >
-                            <Tab title="explorer.witnesses.title">
-                                <div className={cnames("content-block")}>
-                                    <div className="header-selector">
-                                        <div style={{float: "right"}}>
-                                            <Button
-                                                style={{marginRight: "5px"}}
-                                                onClick={this.showWitnessModal.bind(
-                                                    this
-                                                )}
-                                            >
-                                                <Translate content="account.votes.join_witnesses" />
-                                            </Button>
-                                        </div>
-
-                                        <div className="selector inline-block">
-                                            {/* <Link to="/help/voting/worker"><Icon name="question-circle" title="icons.question_cirlce" /></Link> */}
-                                            <Input
-                                                placeholder={"Filter..."}
-                                                value={this.state.filterSearch}
-                                                style={{width: "220px"}}
-                                                onChange={this.handleFilterChange.bind(
-                                                    this
-                                                )}
-                                                addonAfter={
-                                                    <AntIcon type="search" />
-                                                }
-                                            />
-                                        </div>
-                                    </div>
-                                    <VotingAccountsList
-                                        type="witness"
-                                        label="account.votes.add_witness_label"
-                                        items={this.state.all_witnesses}
-                                        validateAccount={this.validateAccount.bind(
-                                            this,
-                                            "witnesses"
-                                        )}
-                                        onAddItem={this.onAddItem.bind(
-                                            this,
-                                            "witnesses"
-                                        )}
-                                        onRemoveItem={this.onRemoveItem.bind(
-                                            this,
-                                            "witnesses"
-                                        )}
-                                        tabIndex={hasProxy ? -1 : 2}
-                                        supported={
-                                            this.state[
-                                                hasProxy
-                                                    ? "proxy_witnesses"
-                                                    : "witnesses"
-                                            ]
-                                        }
-                                        withSelector={false}
-                                        active={globalObject.get(
-                                            "active_witnesses"
-                                        )}
-                                        proxy={this.state.proxy_account_id}
-                                        filterSearch={filterSearch}
-                                    />
-                                </div>
-                                <JoinWitnessesModal
-                                    visible={this.state.showCreateWitnessModal}
-                                    account={account}
-                                    hideModal={this.showWitnessModal.bind(this)}
-                                />
-                            </Tab>
-
-                            <Tab title="explorer.committee_members.title">
-                                <div className="header-selector">
-                                    <div style={{float: "right"}}>
-                                        <Button
-                                            style={{marginRight: "5px"}}
-                                            onClick={this.showCommitteeModal.bind(
-                                                this
-                                            )}
-                                        >
-                                            <Translate content="account.votes.join_committee" />
-                                        </Button>
-                                    </div>
-
-                                    <div className="selector inline-block">
-                                        {/* <Link to="/help/voting/worker"><Icon name="question-circle" title="icons.question_cirlce" /></Link> */}
-                                        <Input
-                                            placeholder={"Filter..."}
-                                            value={this.state.filterSearch}
-                                            style={{width: "220px"}}
-                                            onChange={this.handleFilterChange.bind(
-                                                this
-                                            )}
-                                            addonAfter={
-                                                <AntIcon type="search" />
-                                            }
-                                        />
-                                    </div>
-                                </div>
-                                <div className={cnames("content-block")}>
-                                    <VotingAccountsList
-                                        type="committee"
-                                        label="account.votes.add_committee_label"
-                                        items={this.state.all_committee}
-                                        validateAccount={this.validateAccount.bind(
-                                            this,
-                                            "committee"
-                                        )}
-                                        onAddItem={this.onAddItem.bind(
-                                            this,
-                                            "committee"
-                                        )}
-                                        onRemoveItem={this.onRemoveItem.bind(
-                                            this,
-                                            "committee"
-                                        )}
-                                        tabIndex={hasProxy ? -1 : 3}
-                                        supported={
-                                            this.state[
-                                                hasProxy
-                                                    ? "proxy_committee"
-                                                    : "committee"
-                                            ]
-                                        }
-                                        withSelector={false}
-                                        active={globalObject.get(
-                                            "active_committee_members"
-                                        )}
-                                        proxy={this.state.proxy_account_id}
-                                        filterSearch={filterSearch}
-                                    />
-                                </div>
-                                <JoinCommitteeModal
-                                    visible={
-                                        this.state.showCreateCommitteeModal
-                                    }
-                                    account={account}
-                                    hideModal={this.showCommitteeModal.bind(
-                                        this
-                                    )}
-                                />
-                            </Tab>
-
-                            <Tab title="account.votes.workers_short">
-                                <div className="header-selector">
-                                    <div style={{float: "right"}}>
-                                        <Link
-                                            to="/create-worker"
-                                            className="button primary"
-                                        >
-                                            <Translate content="account.votes.create_worker" />
-                                        </Link>
-                                    </div>
-
-                                    <div className="selector inline-block">
-                                        {/* <Link to="/help/voting/worker"><Icon name="question-circle" title="icons.question_cirlce" /></Link> */}
-                                        <Input
-                                            placeholder={"Filter..."}
-                                            value={this.state.filterSearch}
-                                            style={{width: "220px"}}
-                                            onChange={this.handleFilterChange.bind(
-                                                this
-                                            )}
-                                            addonAfter={
-                                                <AntIcon type="search" />
-                                            }
-                                        />
-                                        <Radio.Group
-                                            defaultValue={1}
-                                            onChange={this._setWorkerTableIndex.bind(
-                                                this
-                                            )}
-                                        >
-                                            <Radio value={0}>
-                                                {counterpart.translate(
-                                                    "account.votes.new",
-                                                    {count: newWorkersLength}
-                                                )}
-                                            </Radio>
-
-                                            <Radio value={1}>
-                                                {counterpart.translate(
-                                                    "account.votes.active",
-                                                    {count: activeWorkersLength}
-                                                )}
-                                            </Radio>
-
-                                            {pollsLength ? (
-                                                <Radio value={3}>
-                                                    {counterpart.translate(
-                                                        "account.votes.polls",
-                                                        {count: pollsLength}
-                                                    )}
-                                                </Radio>
-                                            ) : null}
-
-                                            {expiredWorkersLength ? (
-                                                <Radio value={2}>
-                                                    <Translate content="account.votes.expired" />
-                                                </Radio>
-                                            ) : null}
-                                        </Radio.Group>
-                                    </div>
-
-                                    {hideLegacy}
-                                    <br />
-                                    <br />
-                                    <Row>
-                                        <Col span={3}>
-                                            <Translate content="account.votes.threshold" />{" "}
-                                            (<AssetName name={preferredUnit} />)
-                                        </Col>
-                                        <Col
-                                            span={3}
-                                            style={{
-                                                marginLeft: "10px"
-                                            }}
-                                        >
-                                            <FormattedAsset
-                                                decimalOffset={4}
-                                                hide_asset
-                                                amount={voteThreshold}
-                                                asset="1.3.0"
-                                            />
-                                        </Col>
-                                    </Row>
-                                    <Row>
-                                        <Col span={3}>
-                                            <Translate content="account.votes.total_budget" />{" "}
-                                            (<AssetName name={preferredUnit} />)
-                                        </Col>
-                                        <Col
-                                            span={3}
-                                            style={{
-                                                marginLeft: "10px"
-                                            }}
-                                        >
-                                            {globalObject ? (
-                                                <EquivalentValueComponent
-                                                    hide_asset
-                                                    fromAsset="1.3.0"
-                                                    toAsset={preferredUnit}
-                                                    amount={totalBudget}
-                                                />
-                                            ) : null}
-                                        </Col>
-                                    </Row>
-                                </div>
-                                <WorkersList
-                                    workerTableIndex={workerTableIndex}
-                                    preferredUnit={preferredUnit}
-                                    setWorkersLength={this.setWorkersLength.bind(
-                                        this
-                                    )}
-                                    workerBudget={workerBudget}
-                                    hideLegacyProposals={hideLegacyProposals}
-                                    hasProxy={hasProxy}
-                                    proxy_vote_ids={this.state.proxy_vote_ids}
-                                    vote_ids={this.state.vote_ids}
-                                    onChangeVotes={this.onChangeVotes.bind(
-                                        this
-                                    )}
-                                    getWorkerArray={this._getWorkerArray.bind(
-                                        this
-                                    )}
-                                    filterSearch={filterSearch}
-                                />
-                            </Tab>
+                            {this.getWitnesses(
+                                hasProxy,
+                                globalObject,
+                                filterSearch,
+                                account
+                            )}
+                            {this.getCommittee(
+                                hasProxy,
+                                globalObject,
+                                filterSearch,
+                                account
+                            )}
+                            {this.getWorkers(
+                                newWorkersLength,
+                                activeWorkersLength,
+                                pollsLength,
+                                expiredWorkersLength,
+                                hideLegacy,
+                                preferredUnit,
+                                voteThreshold,
+                                globalObject,
+                                totalBudget,
+                                workerTableIndex,
+                                workerBudget,
+                                hideLegacyProposals,
+                                hasProxy,
+                                filterSearch
+                            )}
                         </Tabs>
                     </div>
                 </div>
             </div>
+        );
+    }
+
+    getWorkers(
+        newWorkersLength,
+        activeWorkersLength,
+        pollsLength,
+        expiredWorkersLength,
+        hideLegacy,
+        preferredUnit,
+        voteThreshold,
+        globalObject,
+        totalBudget,
+        workerTableIndex,
+        workerBudget,
+        hideLegacyProposals,
+        hasProxy,
+        filterSearch
+    ) {
+        return (
+            <Tab title="account.votes.workers_short">
+                <div className="header-selector">
+                    <div style={{float: "right"}}>
+                        <Link to="/create-worker" className="button primary">
+                            <Translate content="account.votes.create_worker" />
+                        </Link>
+                    </div>
+
+                    <div className="selector inline-block">
+                        <Input
+                            placeholder={"Filter..."}
+                            value={this.state.filterSearch}
+                            style={{width: "220px"}}
+                            onChange={this.handleFilterChange.bind(this)}
+                            addonAfter={<AntIcon type="search" />}
+                        />
+                        <Radio.Group
+                            defaultValue={1}
+                            onChange={this._setWorkerTableIndex.bind(this)}
+                        >
+                            <Radio value={0}>
+                                {counterpart.translate("account.votes.new", {
+                                    count: newWorkersLength
+                                })}
+                            </Radio>
+
+                            <Radio value={1}>
+                                {counterpart.translate("account.votes.active", {
+                                    count: activeWorkersLength
+                                })}
+                            </Radio>
+
+                            {pollsLength ? (
+                                <Radio value={3}>
+                                    {counterpart.translate(
+                                        "account.votes.polls",
+                                        {count: pollsLength}
+                                    )}
+                                </Radio>
+                            ) : null}
+
+                            {expiredWorkersLength ? (
+                                <Radio value={2}>
+                                    <Translate content="account.votes.expired" />
+                                </Radio>
+                            ) : null}
+                        </Radio.Group>
+                    </div>
+
+                    {hideLegacy}
+                    <br />
+                    <br />
+                    <Row>
+                        <Col span={3}>
+                            <Translate content="account.votes.threshold" /> (
+                            <AssetName name={preferredUnit} />)
+                        </Col>
+                        <Col
+                            span={3}
+                            style={{
+                                marginLeft: "10px"
+                            }}
+                        >
+                            <FormattedAsset
+                                decimalOffset={4}
+                                hide_asset
+                                amount={voteThreshold}
+                                asset="1.3.0"
+                            />
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col span={3}>
+                            <Translate content="account.votes.total_budget" /> (
+                            <AssetName name={preferredUnit} />)
+                        </Col>
+                        <Col
+                            span={3}
+                            style={{
+                                marginLeft: "10px"
+                            }}
+                        >
+                            {globalObject ? (
+                                <EquivalentValueComponent
+                                    hide_asset
+                                    fromAsset="1.3.0"
+                                    toAsset={preferredUnit}
+                                    amount={totalBudget}
+                                />
+                            ) : null}
+                        </Col>
+                    </Row>
+                </div>
+                <WorkersList
+                    workerTableIndex={workerTableIndex}
+                    preferredUnit={preferredUnit}
+                    setWorkersLength={this.setWorkersLength.bind(this)}
+                    workerBudget={workerBudget}
+                    hideLegacyProposals={hideLegacyProposals}
+                    hasProxy={hasProxy}
+                    proxy_vote_ids={this.state.proxy_vote_ids}
+                    vote_ids={this.state.vote_ids}
+                    onChangeVotes={this.onChangeVotes.bind(this)}
+                    getWorkerArray={this._getWorkerArray.bind(this)}
+                    filterSearch={filterSearch}
+                />
+            </Tab>
+        );
+    }
+
+    getCommittee(hasProxy, globalObject, filterSearch, account) {
+        return (
+            <Tab title="explorer.committee_members.title">
+                <div className="header-selector">
+                    <div style={{float: "right"}}>
+                        <Button
+                            style={{marginRight: "5px"}}
+                            onClick={this.showCommitteeModal.bind(this)}
+                        >
+                            <Translate content="account.votes.join_committee" />
+                        </Button>
+                    </div>
+
+                    <div className="selector inline-block">
+                        <Input
+                            placeholder={"Filter..."}
+                            value={this.state.filterSearch}
+                            style={{width: "220px"}}
+                            onChange={this.handleFilterChange.bind(this)}
+                            addonAfter={<AntIcon type="search" />}
+                        />
+                    </div>
+                </div>
+                <div className={cnames("content-block")}>
+                    <VotingAccountsList
+                        type="committee"
+                        label="account.votes.add_committee_label"
+                        items={this.state.all_committee}
+                        validateAccount={this.validateAccount.bind(
+                            this,
+                            "committee"
+                        )}
+                        onAddItem={this.onAddItem.bind(this, "committee")}
+                        onRemoveItem={this.onRemoveItem.bind(this, "committee")}
+                        tabIndex={hasProxy ? -1 : 3}
+                        supported={
+                            this.state[
+                                hasProxy ? "proxy_committee" : "committee"
+                            ]
+                        }
+                        withSelector={false}
+                        active={globalObject.get("active_committee_members")}
+                        proxy={this.state.proxy_account_id}
+                        filterSearch={filterSearch}
+                    />
+                </div>
+                <JoinCommitteeModal
+                    visible={this.state.showCreateCommitteeModal}
+                    account={account}
+                    hideModal={this.showCommitteeModal.bind(this)}
+                />
+            </Tab>
+        );
+    }
+
+    getWitnesses(hasProxy, globalObject, filterSearch, account) {
+        return (
+            <Tab title="explorer.witnesses.title">
+                <div className={cnames("content-block")}>
+                    <div className="header-selector">
+                        <div style={{float: "right"}}>
+                            <Button
+                                style={{marginRight: "5px"}}
+                                onClick={this.showWitnessModal.bind(this)}
+                            >
+                                <Translate content="account.votes.join_witnesses" />
+                            </Button>
+                        </div>
+
+                        <div className="selector inline-block">
+                            <Input
+                                placeholder={"Filter..."}
+                                value={this.state.filterSearch}
+                                style={{width: "220px"}}
+                                onChange={this.handleFilterChange.bind(this)}
+                                addonAfter={<AntIcon type="search" />}
+                            />
+                        </div>
+                    </div>
+                    <VotingAccountsList
+                        type="witness"
+                        label="account.votes.add_witness_label"
+                        items={this.state.all_witnesses}
+                        validateAccount={this.validateAccount.bind(
+                            this,
+                            "witnesses"
+                        )}
+                        onAddItem={this.onAddItem.bind(this, "witnesses")}
+                        onRemoveItem={this.onRemoveItem.bind(this, "witnesses")}
+                        tabIndex={hasProxy ? -1 : 2}
+                        supported={
+                            this.state[
+                                hasProxy ? "proxy_witnesses" : "witnesses"
+                            ]
+                        }
+                        withSelector={false}
+                        active={globalObject.get("active_witnesses")}
+                        proxy={this.state.proxy_account_id}
+                        filterSearch={filterSearch}
+                    />
+                </div>
+                <JoinWitnessesModal
+                    visible={this.state.showCreateWitnessModal}
+                    account={account}
+                    hideModal={this.showWitnessModal.bind(this)}
+                />
+            </Tab>
         );
     }
 }

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -49,15 +49,9 @@ class AccountVoting extends React.Component {
             vote_ids: Immutable.Set(),
             proxy_vote_ids: Immutable.Set(),
             lastBudgetObject: props.initialBudget.get("id"),
-            workerTableIndex: props.viewSettings.get("workerTableIndex", 1),
             all_witnesses: Immutable.List(),
             all_committee: Immutable.List(),
             hideLegacyProposals: true,
-            newWorkersLength: null,
-            activeWorkersLength: null,
-            pollsLength: null,
-            expiredWorkersLength: null,
-            voteThreshold: null,
             filterSearch: "",
             tabs: [
                 {
@@ -102,13 +96,7 @@ class AccountVoting extends React.Component {
     shouldComponentUpdate(np, ns) {
         return (
             np.location.pathname !== this.props.location.pathname ||
-            ns.workerTableIndex !== this.state.workerTableIndex ||
             ns.prev_proxy_account_id !== this.state.prev_proxy_account_id ||
-            ns.newWorkersLength !== this.state.newWorkersLength ||
-            ns.activeWorkersLength !== this.state.activeWorkersLength ||
-            ns.pollsLength !== this.state.pollsLength ||
-            ns.expiredWorkersLength !== this.state.expiredWorkersLength ||
-            ns.voteThreshold !== this.state.voteThreshold ||
             ns.hideLegacyProposals !== this.state.hideLegacyProposals ||
             ns.vote_ids.size !== this.state.vote_ids.size ||
             ns.current_proxy_input !== this.state.current_proxy_input ||
@@ -551,22 +539,6 @@ class AccountVoting extends React.Component {
         }
     }
 
-    setWorkersLength(
-        newWorkersLength,
-        activeWorkersLength,
-        pollsLength,
-        expiredWorkersLength,
-        voteThreshold
-    ) {
-        this.setState({
-            newWorkersLength,
-            activeWorkersLength,
-            pollsLength,
-            expiredWorkersLength,
-            voteThreshold
-        });
-    }
-
     handleFilterChange(e) {
         this.setState({
             filterSearch: e.target.value || ""
@@ -575,13 +547,7 @@ class AccountVoting extends React.Component {
 
     render() {
         const {
-            workerTableIndex,
             prev_proxy_account_id,
-            newWorkersLength,
-            activeWorkersLength,
-            pollsLength,
-            expiredWorkersLength,
-            voteThreshold,
             hideLegacyProposals,
             filterSearch,
             all_witnesses,
@@ -616,7 +582,6 @@ class AccountVoting extends React.Component {
             this,
             WITNESSES_KEY
         );
-        const setWorkersLength = this.setWorkersLength.bind(this);
         const onChangeVotes = this.onChangeVotes.bind(this);
         const getWorkerArray = this._getWorkerArray.bind(this);
         const addCommitteeHandler = this.onAddItem.bind(this, COMMITTEE_KEY);
@@ -695,17 +660,8 @@ class AccountVoting extends React.Component {
                                             }
                                             vote_ids={vote_ids}
                                             proxy_vote_ids={proxy_vote_ids}
-                                            newWorkersLength={newWorkersLength}
-                                            activeWorkersLength={
-                                                activeWorkersLength
-                                            }
-                                            pollsLength={pollsLength}
-                                            expiredWorkersLength={
-                                                expiredWorkersLength
-                                            }
                                             hideLegacy={hideLegacy}
                                             preferredUnit={preferredUnit}
-                                            voteThreshold={voteThreshold}
                                             totalBudget={totalBudget}
                                             workerBudget={workerBudget}
                                             hideLegacyProposals={
@@ -713,8 +669,9 @@ class AccountVoting extends React.Component {
                                             }
                                             onChangeVotes={onChangeVotes}
                                             getWorkerArray={getWorkerArray}
-                                            setWorkersLength={setWorkersLength}
-                                            workerTableIndex={workerTableIndex}
+                                            viewSettings={
+                                                this.props.viewSettings
+                                            }
                                         />
                                     </div>
                                 </Tabs.TabPane>

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -4,7 +4,6 @@ import Immutable from "immutable";
 import Translate from "react-translate-component";
 import accountUtils from "common/account_utils";
 import {ChainStore, FetchChainObjects} from "bitsharesjs";
-import {Tab} from "../Utility/Tabs";
 import BindToChainState from "../Utility/BindToChainState";
 import ChainTypes from "../Utility/ChainTypes";
 import {Link} from "react-router-dom";
@@ -37,6 +36,10 @@ class AccountVoting extends React.Component {
         super(props);
         const proxyId = props.proxy.get("id");
         const proxyName = props.proxy.get("name");
+        const accountName =
+            typeof props.account === "string"
+                ? props.account
+                : props.account.get("name");
         this.state = {
             proxy_account_id: proxyId === "1.2.5" ? "" : proxyId, //"1.2.16",
             prev_proxy_account_id: proxyId === "1.2.5" ? "" : proxyId,
@@ -59,19 +62,19 @@ class AccountVoting extends React.Component {
             tabs: [
                 {
                     name: "witnesses",
-                    link: "/account/twat123/voting/witnesses",
+                    link: "/account/" + accountName + "/voting/witnesses",
                     translate: "explorer.witnesses.title",
                     content: Witnesses
                 },
                 {
                     name: "committee",
-                    link: "/account/twat123/voting/committee",
+                    link: "/account/" + accountName + "/voting/committee",
                     translate: "explorer.committee_members.title",
                     content: Committee
                 },
                 {
                     name: "workers",
-                    link: "/account/twat123/voting/workers",
+                    link: "/account/" + accountName + "/voting/workers",
                     translate: "account.votes.workers_short",
                     content: Workers
                 }

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -54,8 +54,7 @@ class AccountVoting extends React.Component {
             pollsLength: null,
             expiredWorkersLength: null,
             voteThreshold: null,
-            filterSearch: "",
-            showCreateCommitteeModal: false
+            filterSearch: ""
         };
         this.onProxyAccountFound = this.onProxyAccountFound.bind(this);
         this.onPublish = this.onPublish.bind(this);
@@ -77,8 +76,6 @@ class AccountVoting extends React.Component {
 
     shouldComponentUpdate(np, ns) {
         return (
-            ns.showCreateCommitteeModal !==
-                this.state.showCreateCommitteeModal ||
             ns.workerTableIndex !== this.state.workerTableIndex ||
             ns.prev_proxy_account_id !== this.state.prev_proxy_account_id ||
             ns.newWorkersLength !== this.state.newWorkersLength ||
@@ -87,7 +84,6 @@ class AccountVoting extends React.Component {
             ns.expiredWorkersLength !== this.state.expiredWorkersLength ||
             ns.voteThreshold !== this.state.voteThreshold ||
             ns.hideLegacyProposals !== this.state.hideLegacyProposals ||
-            ns.workerTableIndex !== this.state.workerTableIndex ||
             ns.vote_ids.size !== this.state.vote_ids.size ||
             ns.current_proxy_input !== this.state.current_proxy_input ||
             ns.filterSearch !== this.state.filterSearch ||
@@ -258,12 +254,6 @@ class AccountVoting extends React.Component {
 
     onPublish() {
         this.publish(this.state.proxy_account_id);
-    }
-
-    showCommitteeModal() {
-        this.setState({
-            showCreateCommitteeModal: !this.state.showCreateCommitteeModal
-        });
     }
 
     publish(new_proxy_id) {
@@ -535,12 +525,6 @@ class AccountVoting extends React.Component {
         }
     }
 
-    _setWorkerTableIndex(e) {
-        this.setState({
-            workerTableIndex: e.target.value
-        });
-    }
-
     setWorkersLength(
         newWorkersLength,
         activeWorkersLength,
@@ -801,11 +785,6 @@ class AccountVoting extends React.Component {
         filterSearch
     ) {
         const {vote_ids, proxy_vote_ids} = this.state;
-        const setWorkerTableIndex = e => {
-            this.setState({
-                workerTableIndex: e.target.value
-            });
-        };
 
         const setWorkersLength = this.setWorkersLength.bind(this);
         const onFilterChange = this.handleFilterChange.bind(this);
@@ -833,6 +812,7 @@ class AccountVoting extends React.Component {
                     onChangeVotes={onChangeVotes}
                     getWorkerArray={getWorkerArray}
                     setWorkersLength={setWorkersLength}
+                    workerTableIndex={workerTableIndex}
                 />
             </Tab>
         );

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -1,9 +1,10 @@
 import React from "react";
+import {withRouter} from "react-router";
 import Immutable from "immutable";
 import Translate from "react-translate-component";
 import accountUtils from "common/account_utils";
 import {ChainStore, FetchChainObjects} from "bitsharesjs";
-import {Tabs, Tab} from "../Utility/Tabs";
+import {Tab} from "../Utility/Tabs";
 import BindToChainState from "../Utility/BindToChainState";
 import ChainTypes from "../Utility/ChainTypes";
 import {Link} from "react-router-dom";
@@ -12,7 +13,7 @@ import AccountSelector from "./AccountSelector";
 import Icon from "../Icon/Icon";
 import counterpart from "counterpart";
 import SettingsStore from "stores/SettingsStore";
-import {Switch, Tooltip, Button} from "bitshares-ui-style-guide";
+import {Switch, Tooltip, Button, Tabs} from "bitshares-ui-style-guide";
 import AccountStore from "stores/AccountStore";
 import Witnesses from "./Voting/Witnesses";
 import Committee from "./Voting/Committee";
@@ -54,8 +55,29 @@ class AccountVoting extends React.Component {
             pollsLength: null,
             expiredWorkersLength: null,
             voteThreshold: null,
-            filterSearch: ""
+            filterSearch: "",
+            tabs: [
+                {
+                    name: "witnesses",
+                    link: "/account/twat123/voting/witnesses",
+                    translate: "explorer.witnesses.title",
+                    content: Witnesses
+                },
+                {
+                    name: "committee",
+                    link: "/account/twat123/voting/committee",
+                    translate: "explorer.committee_members.title",
+                    content: Committee
+                },
+                {
+                    name: "workers",
+                    link: "/account/twat123/voting/workers",
+                    translate: "account.votes.workers_short",
+                    content: Workers
+                }
+            ]
         };
+
         this.onProxyAccountFound = this.onProxyAccountFound.bind(this);
         this.onPublish = this.onPublish.bind(this);
         this.onReset = this.onReset.bind(this);
@@ -76,6 +98,7 @@ class AccountVoting extends React.Component {
 
     shouldComponentUpdate(np, ns) {
         return (
+            np.location.pathname !== this.props.location.pathname ||
             ns.workerTableIndex !== this.state.workerTableIndex ||
             ns.prev_proxy_account_id !== this.state.prev_proxy_account_id ||
             ns.newWorkersLength !== this.state.newWorkersLength ||
@@ -548,7 +571,7 @@ class AccountVoting extends React.Component {
     }
 
     render() {
-        let {
+        const {
             workerTableIndex,
             prev_proxy_account_id,
             newWorkersLength,
@@ -557,26 +580,161 @@ class AccountVoting extends React.Component {
             expiredWorkersLength,
             voteThreshold,
             hideLegacyProposals,
-            filterSearch
+            filterSearch,
+            all_witnesses,
+            proxy_witnesses,
+            witnesses,
+            all_committee,
+            proxy_committee,
+            committee,
+            vote_ids,
+            proxy_vote_ids,
+            proxy_account_id
         } = this.state;
         const accountHasProxy = !!prev_proxy_account_id;
-        let preferredUnit = this.props.settings.get("unit") || "1.3.0";
-        let hasProxy = !!this.state.proxy_account_id; // this.props.account.getIn(["options", "voting_account"]) !== "1.2.5";
-        let {globalObject, account} = this.props;
+        const preferredUnit = this.props.settings.get("unit") || "1.3.0";
+        const hasProxy = !!proxy_account_id; // this.props.account.getIn(["options", "voting_account"]) !== "1.2.5";
+        const {globalObject, account} = this.props;
+        const {totalBudget, workerBudget} = this._getBudgets(globalObject);
+
+        const actionButtons = this._getActionButtons();
+
+        const proxyInput = this._getProxyInput(accountHasProxy);
+
+        const hideLegacy = this._getHideLegacyOptions();
+
+        const onFilterChange = this.handleFilterChange.bind(this);
+        const validateAccountHandler = this.validateAccount.bind(
+            this,
+            WITNESSES_KEY
+        );
+        const addWitnessHandler = this.onAddItem.bind(this, WITNESSES_KEY);
+        const removeWitnessHandler = this.onRemoveItem.bind(
+            this,
+            WITNESSES_KEY
+        );
+        const setWorkersLength = this.setWorkersLength.bind(this);
+        const onChangeVotes = this.onChangeVotes.bind(this);
+        const getWorkerArray = this._getWorkerArray.bind(this);
+        const addCommitteeHandler = this.onAddItem.bind(this, COMMITTEE_KEY);
+        const removeCommitteeHandler = this.onRemoveItem.bind(
+            this,
+            COMMITTEE_KEY
+        );
+
+        const onTabChange = value => {
+            this.props.history.push(value);
+        };
+
+        return (
+            <div className="grid-content no-padding page-layout ">
+                <div className="main-content content-block small-12 voting">
+                    <div className="padding">
+                        <div>
+                            <Translate content="voting.title" component="h1" />
+                            <Translate
+                                content="voting.description"
+                                component="p"
+                            />
+                        </div>
+                        <div className="proxy-row">
+                            {proxyInput}
+                            {actionButtons}
+                        </div>
+                    </div>
+
+                    <Tabs
+                        activeKey={this.props.location.pathname}
+                        animated={false}
+                        style={{
+                            display: "table",
+                            height: "100%",
+                            width: "100%"
+                        }}
+                        onChange={onTabChange}
+                    >
+                        {this.state.tabs.map(tab => {
+                            const TabContent = tab.content;
+
+                            return (
+                                <Tabs.TabPane
+                                    key={tab.link}
+                                    tab={counterpart.translate(tab.translate)}
+                                >
+                                    <div className="padding">
+                                        <TabContent
+                                            all_witnesses={all_witnesses}
+                                            proxy_witnesses={proxy_witnesses}
+                                            witnesses={witnesses}
+                                            proxy_account_id={proxy_account_id}
+                                            onFilterChange={onFilterChange}
+                                            validateAccountHandler={
+                                                validateAccountHandler
+                                            }
+                                            addWitnessHandler={
+                                                addWitnessHandler
+                                            }
+                                            removeWitnessHandler={
+                                                removeWitnessHandler
+                                            }
+                                            hasProxy={hasProxy}
+                                            globalObject={globalObject}
+                                            filterSearch={filterSearch}
+                                            account={account}
+                                            all_committee={all_committee}
+                                            proxy_committee={proxy_committee}
+                                            committee={committee}
+                                            addCommitteeHandler={
+                                                addCommitteeHandler
+                                            }
+                                            removeCommitteeHandler={
+                                                removeCommitteeHandler
+                                            }
+                                            vote_ids={vote_ids}
+                                            proxy_vote_ids={proxy_vote_ids}
+                                            newWorkersLength={newWorkersLength}
+                                            activeWorkersLength={
+                                                activeWorkersLength
+                                            }
+                                            pollsLength={pollsLength}
+                                            expiredWorkersLength={
+                                                expiredWorkersLength
+                                            }
+                                            hideLegacy={hideLegacy}
+                                            preferredUnit={preferredUnit}
+                                            voteThreshold={voteThreshold}
+                                            totalBudget={totalBudget}
+                                            workerBudget={workerBudget}
+                                            hideLegacyProposals={
+                                                hideLegacyProposals
+                                            }
+                                            onChangeVotes={onChangeVotes}
+                                            getWorkerArray={getWorkerArray}
+                                            setWorkersLength={setWorkersLength}
+                                            workerTableIndex={workerTableIndex}
+                                        />
+                                    </div>
+                                </Tabs.TabPane>
+                            );
+                        })}
+                    </Tabs>
+                </div>
+            </div>
+        );
+    }
+
+    _getBudgets(globalObject) {
         let budgetObject;
         if (this.state.lastBudgetObject) {
             budgetObject = ChainStore.getObject(this.state.lastBudgetObject);
         }
-
         let totalBudget = 0;
-        // let unusedBudget = 0;
         let workerBudget = globalObject
             ? parseInt(
                   globalObject.getIn(["parameters", "worker_budget_per_day"]),
                   10
               )
             : 0;
-
         if (budgetObject) {
             workerBudget = Math.min(
                 24 * budgetObject.getIn(["record", "worker_budget"]),
@@ -587,39 +745,11 @@ class AccountVoting extends React.Component {
                 workerBudget
             );
         }
+        return {totalBudget, workerBudget};
+    }
 
-        let actionButtons = (
-            <Tooltip
-                title={counterpart.translate(
-                    "account.votes.cast_votes_through_one_operation"
-                )}
-                mouseEnterDelay={0.5}
-            >
-                <div
-                    style={{
-                        float: "right"
-                    }}
-                >
-                    <Button
-                        type="primary"
-                        onClick={this.onPublish}
-                        tabIndex={4}
-                        disabled={!this.isChanged() ? true : undefined}
-                    >
-                        <Translate content="account.votes.publish" />
-                    </Button>
-                    <Button
-                        style={{marginLeft: "8px"}}
-                        onClick={this.onReset}
-                        tabIndex={8}
-                    >
-                        <Translate content="account.perm.reset" />
-                    </Button>
-                </div>
-            </Tooltip>
-        );
-
-        let proxyInput = (
+    _getProxyInput(accountHasProxy) {
+        return (
             <React.Fragment>
                 <AccountSelector
                     label="account.votes.proxy_short"
@@ -670,23 +800,10 @@ class AccountVoting extends React.Component {
                 )}
             </React.Fragment>
         );
+    }
 
-        const saveText = (
-            <div
-                className="inline-block"
-                style={{
-                    float: "right",
-                    visibility: this.isChanged() ? "visible" : "hidden",
-                    color: "red",
-                    padding: "0.85rem",
-                    fontSize: "0.9rem"
-                }}
-            >
-                <Translate content="account.votes.save_finish" />
-            </div>
-        );
-
-        const hideLegacy = (
+    _getHideLegacyOptions() {
+        return (
             <div
                 className="inline-block"
                 style={{marginLeft: "0.5em"}}
@@ -707,191 +824,38 @@ class AccountVoting extends React.Component {
                 </Tooltip>
             </div>
         );
+    }
 
+    _getActionButtons() {
         return (
-            <div className="grid-content no-padding page-layout ">
-                <div className="main-content content-block small-12 voting">
-                    <div className="padding">
-                        <div>
-                            <Translate content="voting.title" component="h1" />
-                            <Translate
-                                content="voting.description"
-                                component="p"
-                            />
-                        </div>
-                        <div className="proxy-row">
-                            {proxyInput}
-                            {actionButtons}
-                        </div>
-                    </div>
-                    <div className="tabs-container generic-bordered-box">
-                        <Tabs
-                            setting="votingTab"
-                            className="account-tabs"
-                            defaultActiveTab={1}
-                            segmented={false}
-                            actionButtons={saveText}
-                            tabsClass="account-overview no-padding bordered-header content-block"
-                        >
-                            {this.getWitnesses(
-                                hasProxy,
-                                globalObject,
-                                filterSearch,
-                                account
-                            )}
-                            {this.getCommittee(
-                                hasProxy,
-                                globalObject,
-                                filterSearch,
-                                account
-                            )}
-                            {this.getWorkers(
-                                newWorkersLength,
-                                activeWorkersLength,
-                                pollsLength,
-                                expiredWorkersLength,
-                                hideLegacy,
-                                preferredUnit,
-                                voteThreshold,
-                                globalObject,
-                                totalBudget,
-                                workerTableIndex,
-                                workerBudget,
-                                hideLegacyProposals,
-                                hasProxy,
-                                filterSearch
-                            )}
-                        </Tabs>
-                    </div>
+            <Tooltip
+                title={counterpart.translate(
+                    "account.votes.cast_votes_through_one_operation"
+                )}
+                mouseEnterDelay={0.5}
+            >
+                <div
+                    style={{
+                        float: "right"
+                    }}
+                >
+                    <Button
+                        type="primary"
+                        onClick={this.onPublish}
+                        tabIndex={4}
+                        disabled={!this.isChanged() ? true : undefined}
+                    >
+                        <Translate content="account.votes.publish" />
+                    </Button>
+                    <Button
+                        style={{marginLeft: "8px"}}
+                        onClick={this.onReset}
+                        tabIndex={8}
+                    >
+                        <Translate content="account.perm.reset" />
+                    </Button>
                 </div>
-            </div>
-        );
-    }
-
-    getWorkers(
-        newWorkersLength,
-        activeWorkersLength,
-        pollsLength,
-        expiredWorkersLength,
-        hideLegacy,
-        preferredUnit,
-        voteThreshold,
-        globalObject,
-        totalBudget,
-        workerTableIndex,
-        workerBudget,
-        hideLegacyProposals,
-        hasProxy,
-        filterSearch
-    ) {
-        const {vote_ids, proxy_vote_ids} = this.state;
-
-        const setWorkersLength = this.setWorkersLength.bind(this);
-        const onFilterChange = this.handleFilterChange.bind(this);
-        const onChangeVotes = this.onChangeVotes.bind(this);
-        const getWorkerArray = this._getWorkerArray.bind(this);
-        return (
-            <Tab title="account.votes.workers_short">
-                <Workers
-                    vote_ids={vote_ids}
-                    proxy_vote_ids={proxy_vote_ids}
-                    newWorkersLength={newWorkersLength}
-                    activeWorkersLength={activeWorkersLength}
-                    pollsLength={pollsLength}
-                    expiredWorkersLength={expiredWorkersLength}
-                    hideLegacy={hideLegacy}
-                    preferredUnit={preferredUnit}
-                    voteThreshold={voteThreshold}
-                    globalObject={globalObject}
-                    totalBudget={totalBudget}
-                    workerBudget={workerBudget}
-                    hideLegacyProposals={hideLegacyProposals}
-                    hasProxy={hasProxy}
-                    filterSearch={filterSearch}
-                    onFilterChange={onFilterChange}
-                    onChangeVotes={onChangeVotes}
-                    getWorkerArray={getWorkerArray}
-                    setWorkersLength={setWorkersLength}
-                    workerTableIndex={workerTableIndex}
-                />
-            </Tab>
-        );
-    }
-
-    getCommittee(hasProxy, globalObject, filterSearch, account) {
-        const {
-            all_committee,
-            proxy_committee,
-            committee,
-            proxy_account_id
-        } = this.state;
-        const onFilterChange = this.handleFilterChange.bind(this);
-        const validateAccountHandler = this.validateAccount.bind(
-            this,
-            COMMITTEE_KEY
-        );
-        const addCommitteeHandler = this.onAddItem.bind(this, COMMITTEE_KEY);
-        const removeCommitteeHandler = this.onRemoveItem.bind(
-            this,
-            COMMITTEE_KEY
-        );
-        return (
-            <Tab title="explorer.committee_members.title">
-                <Committee
-                    all_committee={all_committee}
-                    proxy_committee={proxy_committee}
-                    committee={committee}
-                    proxy_account_id={proxy_account_id}
-                    onFilterChange={onFilterChange}
-                    validateAccountHandler={validateAccountHandler}
-                    addCommitteeHandler={addCommitteeHandler}
-                    removeCommitteeHandler={removeCommitteeHandler}
-                    hasProxy={hasProxy}
-                    globalObject={globalObject}
-                    filterSearch={filterSearch}
-                    account={account}
-                />
-            </Tab>
-        );
-    }
-
-    getWitnesses(hasProxy, globalObject, filterSearch, account) {
-        // make it props
-        // hasProxy, globalObject, filterSearch, account
-        // all_witnesses, proxy_witnesses, witnesses, proxy_account_id;
-        const onFilterChange = this.handleFilterChange.bind(this);
-        const validateAccountHandler = this.validateAccount.bind(
-            this,
-            WITNESSES_KEY
-        );
-        const addWitnessHandler = this.onAddItem.bind(this, WITNESSES_KEY);
-        const removeWitnessHandler = this.onRemoveItem.bind(
-            this,
-            WITNESSES_KEY
-        );
-        const {
-            all_witnesses,
-            proxy_witnesses,
-            witnesses,
-            proxy_account_id
-        } = this.state;
-        return (
-            <Tab title="explorer.witnesses.title">
-                <Witnesses
-                    all_witnesses={all_witnesses}
-                    proxy_witnesses={proxy_witnesses}
-                    witnesses={witnesses}
-                    proxy_account_id={proxy_account_id}
-                    onFilterChange={onFilterChange}
-                    validateAccountHandler={validateAccountHandler}
-                    addWitnessHandler={addWitnessHandler}
-                    removeWitnessHandler={removeWitnessHandler}
-                    hasProxy={hasProxy}
-                    globalObject={globalObject}
-                    filterSearch={filterSearch}
-                    account={account}
-                />
-            </Tab>
+            </Tooltip>
         );
     }
 }
@@ -927,4 +891,4 @@ const FillMissingProps = props => {
     return <AccountVoting {...props} {...missingProps} />;
 };
 
-export default FillMissingProps;
+export default withRouter(FillMissingProps);

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -3,9 +3,6 @@ import Immutable from "immutable";
 import Translate from "react-translate-component";
 import accountUtils from "common/account_utils";
 import {ChainStore, FetchChainObjects} from "bitsharesjs";
-import WorkersList from "./WorkersList";
-import VotingAccountsList from "./VotingAccountsList";
-import cnames from "classnames";
 import {Tabs, Tab} from "../Utility/Tabs";
 import BindToChainState from "../Utility/BindToChainState";
 import ChainTypes from "../Utility/ChainTypes";
@@ -13,24 +10,13 @@ import {Link} from "react-router-dom";
 import ApplicationApi from "api/ApplicationApi";
 import AccountSelector from "./AccountSelector";
 import Icon from "../Icon/Icon";
-import AssetName from "../Utility/AssetName";
 import counterpart from "counterpart";
-import {EquivalentValueComponent} from "../Utility/EquivalentValueComponent";
-import FormattedAsset from "../Utility/FormattedAsset";
 import SettingsStore from "stores/SettingsStore";
-import {
-    Switch,
-    Tooltip,
-    Row,
-    Col,
-    Radio,
-    Input,
-    Icon as AntIcon,
-    Button
-} from "bitshares-ui-style-guide";
+import {Switch, Tooltip, Button} from "bitshares-ui-style-guide";
 import AccountStore from "stores/AccountStore";
 import Witnesses from "./Voting/Witnesses";
 import Committee from "./Voting/Committee";
+import Workers from "./Voting/Workers";
 
 const WITNESSES_KEY = "witnesses";
 const COMMITTEE_KEY = "committee";
@@ -592,9 +578,6 @@ class AccountVoting extends React.Component {
         const accountHasProxy = !!prev_proxy_account_id;
         let preferredUnit = this.props.settings.get("unit") || "1.3.0";
         let hasProxy = !!this.state.proxy_account_id; // this.props.account.getIn(["options", "voting_account"]) !== "1.2.5";
-        let publish_buttons_class = cnames("button", {
-            disabled: !this.isChanged()
-        });
         let {globalObject, account} = this.props;
         let budgetObject;
         if (this.state.lastBudgetObject) {
@@ -817,131 +800,50 @@ class AccountVoting extends React.Component {
         hasProxy,
         filterSearch
     ) {
+        const {vote_ids, proxy_vote_ids} = this.state;
+        const setWorkerTableIndex = e => {
+            this.setState({
+                workerTableIndex: e.target.value
+            });
+        };
+
+        const setWorkersLength = this.setWorkersLength.bind(this);
+        const onFilterChange = this.handleFilterChange.bind(this);
+        const onChangeVotes = this.onChangeVotes.bind(this);
+        const getWorkerArray = this._getWorkerArray.bind(this);
         return (
             <Tab title="account.votes.workers_short">
-                <div className="header-selector">
-                    <div style={{float: "right"}}>
-                        <Link to="/create-worker" className="button primary">
-                            <Translate content="account.votes.create_worker" />
-                        </Link>
-                    </div>
-
-                    <div className="selector inline-block">
-                        <Input
-                            placeholder={"Filter..."}
-                            value={this.state.filterSearch}
-                            style={{width: "220px"}}
-                            onChange={this.handleFilterChange.bind(this)}
-                            addonAfter={<AntIcon type="search" />}
-                        />
-                        <Radio.Group
-                            defaultValue={1}
-                            onChange={this._setWorkerTableIndex.bind(this)}
-                        >
-                            <Radio value={0}>
-                                {counterpart.translate("account.votes.new", {
-                                    count: newWorkersLength
-                                })}
-                            </Radio>
-
-                            <Radio value={1}>
-                                {counterpart.translate("account.votes.active", {
-                                    count: activeWorkersLength
-                                })}
-                            </Radio>
-
-                            {pollsLength ? (
-                                <Radio value={3}>
-                                    {counterpart.translate(
-                                        "account.votes.polls",
-                                        {count: pollsLength}
-                                    )}
-                                </Radio>
-                            ) : null}
-
-                            {expiredWorkersLength ? (
-                                <Radio value={2}>
-                                    <Translate content="account.votes.expired" />
-                                </Radio>
-                            ) : null}
-                        </Radio.Group>
-                    </div>
-
-                    {hideLegacy}
-                    <br />
-                    <br />
-                    <Row>
-                        <Col span={3}>
-                            <Translate content="account.votes.threshold" /> (
-                            <AssetName name={preferredUnit} />)
-                        </Col>
-                        <Col
-                            span={3}
-                            style={{
-                                marginLeft: "10px"
-                            }}
-                        >
-                            <FormattedAsset
-                                decimalOffset={4}
-                                hide_asset
-                                amount={voteThreshold}
-                                asset="1.3.0"
-                            />
-                        </Col>
-                    </Row>
-                    <Row>
-                        <Col span={3}>
-                            <Translate content="account.votes.total_budget" /> (
-                            <AssetName name={preferredUnit} />)
-                        </Col>
-                        <Col
-                            span={3}
-                            style={{
-                                marginLeft: "10px"
-                            }}
-                        >
-                            {globalObject ? (
-                                <EquivalentValueComponent
-                                    hide_asset
-                                    fromAsset="1.3.0"
-                                    toAsset={preferredUnit}
-                                    amount={totalBudget}
-                                />
-                            ) : null}
-                        </Col>
-                    </Row>
-                </div>
-                <WorkersList
-                    workerTableIndex={workerTableIndex}
+                <Workers
+                    vote_ids={vote_ids}
+                    proxy_vote_ids={proxy_vote_ids}
+                    newWorkersLength={newWorkersLength}
+                    activeWorkersLength={activeWorkersLength}
+                    pollsLength={pollsLength}
+                    expiredWorkersLength={expiredWorkersLength}
+                    hideLegacy={hideLegacy}
                     preferredUnit={preferredUnit}
-                    setWorkersLength={this.setWorkersLength.bind(this)}
+                    voteThreshold={voteThreshold}
+                    globalObject={globalObject}
+                    totalBudget={totalBudget}
                     workerBudget={workerBudget}
                     hideLegacyProposals={hideLegacyProposals}
                     hasProxy={hasProxy}
-                    proxy_vote_ids={this.state.proxy_vote_ids}
-                    vote_ids={this.state.vote_ids}
-                    onChangeVotes={this.onChangeVotes.bind(this)}
-                    getWorkerArray={this._getWorkerArray.bind(this)}
                     filterSearch={filterSearch}
+                    onFilterChange={onFilterChange}
+                    onChangeVotes={onChangeVotes}
+                    getWorkerArray={getWorkerArray}
+                    setWorkersLength={setWorkersLength}
                 />
             </Tab>
         );
     }
 
     getCommittee(hasProxy, globalObject, filterSearch, account) {
-        // this.state = {showCreateCommitteeModal: false};
-        const showCommitteeModal = () => {
-            this.setState({
-                showCreateCommitteeModal: !this.state.showCreateCommitteeModal
-            });
-        };
-
         const {
             all_committee,
             proxy_committee,
             committee,
-            proxy_account_id,
-            showCreateCommitteeModal
+            proxy_account_id
         } = this.state;
         const onFilterChange = this.handleFilterChange.bind(this);
         const validateAccountHandler = this.validateAccount.bind(

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -29,8 +29,10 @@ import {
     Button
 } from "bitshares-ui-style-guide";
 import AccountStore from "stores/AccountStore";
-import JoinWitnessesModal from "../Modal/JoinWitnessesModal";
 import JoinCommitteeModal from "../Modal/JoinCommitteeModal";
+import Witnesses from "./Voting/Witnesses";
+
+const WITNESSES_KEY = "witnesses";
 
 class AccountVoting extends React.Component {
     static propTypes = {
@@ -66,8 +68,7 @@ class AccountVoting extends React.Component {
             expiredWorkersLength: null,
             voteThreshold: null,
             filterSearch: "",
-            showCreateCommitteeModal: false,
-            showCreateWitnessModal: false
+            showCreateCommitteeModal: false
         };
         this.onProxyAccountFound = this.onProxyAccountFound.bind(this);
         this.onPublish = this.onPublish.bind(this);
@@ -89,7 +90,6 @@ class AccountVoting extends React.Component {
 
     shouldComponentUpdate(np, ns) {
         return (
-            ns.showCreateWitnessModal !== this.state.showCreateWitnessModal ||
             ns.showCreateCommitteeModal !==
                 this.state.showCreateCommitteeModal ||
             ns.workerTableIndex !== this.state.workerTableIndex ||
@@ -213,9 +213,9 @@ class AccountVoting extends React.Component {
         );
     }
 
-    _getVoteObjects(type = "witnesses", vote_ids) {
+    _getVoteObjects(type = WITNESSES_KEY, vote_ids) {
         let current = this.state[`all_${type}`];
-        const isWitness = type === "witnesses";
+        const isWitness = type === WITNESSES_KEY;
         let lastIdx;
         if (!vote_ids) {
             vote_ids = [];
@@ -271,13 +271,6 @@ class AccountVoting extends React.Component {
 
     onPublish() {
         this.publish(this.state.proxy_account_id);
-    }
-
-    showWitnessModal() {
-        console.log("asdasd");
-        this.setState({
-            showCreateWitnessModal: !this.state.showCreateWitnessModal
-        });
     }
 
     showCommitteeModal() {
@@ -431,7 +424,7 @@ class AccountVoting extends React.Component {
 
     validateAccount(collection, account) {
         if (!account) return null;
-        if (collection === "witnesses") {
+        if (collection === WITNESSES_KEY) {
             return FetchChainObjects(
                 ChainStore.getWitnessById,
                 [account.get("id")],
@@ -990,55 +983,40 @@ class AccountVoting extends React.Component {
     }
 
     getWitnesses(hasProxy, globalObject, filterSearch, account) {
+        // make it props
+        // hasProxy, globalObject, filterSearch, account
+        // all_witnesses, proxy_witnesses, witnesses, proxy_account_id;
+        const onFilterChange = this.handleFilterChange.bind(this);
+        const validateAccountHandler = this.validateAccount.bind(
+            this,
+            WITNESSES_KEY
+        );
+        const addWitnessHandler = this.onAddItem.bind(this, WITNESSES_KEY);
+        const removeWitnessHandler = this.onRemoveItem.bind(
+            this,
+            WITNESSES_KEY
+        );
+        const {
+            all_witnesses,
+            proxy_witnesses,
+            witnesses,
+            proxy_account_id
+        } = this.state;
         return (
             <Tab title="explorer.witnesses.title">
-                <div className={cnames("content-block")}>
-                    <div className="header-selector">
-                        <div style={{float: "right"}}>
-                            <Button
-                                style={{marginRight: "5px"}}
-                                onClick={this.showWitnessModal.bind(this)}
-                            >
-                                <Translate content="account.votes.join_witnesses" />
-                            </Button>
-                        </div>
-
-                        <div className="selector inline-block">
-                            <Input
-                                placeholder={"Filter..."}
-                                value={this.state.filterSearch}
-                                style={{width: "220px"}}
-                                onChange={this.handleFilterChange.bind(this)}
-                                addonAfter={<AntIcon type="search" />}
-                            />
-                        </div>
-                    </div>
-                    <VotingAccountsList
-                        type="witness"
-                        label="account.votes.add_witness_label"
-                        items={this.state.all_witnesses}
-                        validateAccount={this.validateAccount.bind(
-                            this,
-                            "witnesses"
-                        )}
-                        onAddItem={this.onAddItem.bind(this, "witnesses")}
-                        onRemoveItem={this.onRemoveItem.bind(this, "witnesses")}
-                        tabIndex={hasProxy ? -1 : 2}
-                        supported={
-                            this.state[
-                                hasProxy ? "proxy_witnesses" : "witnesses"
-                            ]
-                        }
-                        withSelector={false}
-                        active={globalObject.get("active_witnesses")}
-                        proxy={this.state.proxy_account_id}
-                        filterSearch={filterSearch}
-                    />
-                </div>
-                <JoinWitnessesModal
-                    visible={this.state.showCreateWitnessModal}
+                <Witnesses
+                    all_witnesses={all_witnesses}
+                    proxy_witnesses={proxy_witnesses}
+                    witnesses={witnesses}
+                    proxy_account_id={proxy_account_id}
+                    onFilterChange={onFilterChange}
+                    validateAccountHandler={validateAccountHandler}
+                    addWitnessHandler={addWitnessHandler}
+                    removeWitnessHandler={removeWitnessHandler}
+                    hasProxy={hasProxy}
+                    globalObject={globalObject}
+                    filterSearch={filterSearch}
                     account={account}
-                    hideModal={this.showWitnessModal.bind(this)}
                 />
             </Tab>
         );

--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -29,10 +29,11 @@ import {
     Button
 } from "bitshares-ui-style-guide";
 import AccountStore from "stores/AccountStore";
-import JoinCommitteeModal from "../Modal/JoinCommitteeModal";
 import Witnesses from "./Voting/Witnesses";
+import Committee from "./Voting/Committee";
 
 const WITNESSES_KEY = "witnesses";
+const COMMITTEE_KEY = "committee";
 
 class AccountVoting extends React.Component {
     static propTypes = {
@@ -928,55 +929,45 @@ class AccountVoting extends React.Component {
     }
 
     getCommittee(hasProxy, globalObject, filterSearch, account) {
+        // this.state = {showCreateCommitteeModal: false};
+        const showCommitteeModal = () => {
+            this.setState({
+                showCreateCommitteeModal: !this.state.showCreateCommitteeModal
+            });
+        };
+
+        const {
+            all_committee,
+            proxy_committee,
+            committee,
+            proxy_account_id,
+            showCreateCommitteeModal
+        } = this.state;
+        const onFilterChange = this.handleFilterChange.bind(this);
+        const validateAccountHandler = this.validateAccount.bind(
+            this,
+            COMMITTEE_KEY
+        );
+        const addCommitteeHandler = this.onAddItem.bind(this, COMMITTEE_KEY);
+        const removeCommitteeHandler = this.onRemoveItem.bind(
+            this,
+            COMMITTEE_KEY
+        );
         return (
             <Tab title="explorer.committee_members.title">
-                <div className="header-selector">
-                    <div style={{float: "right"}}>
-                        <Button
-                            style={{marginRight: "5px"}}
-                            onClick={this.showCommitteeModal.bind(this)}
-                        >
-                            <Translate content="account.votes.join_committee" />
-                        </Button>
-                    </div>
-
-                    <div className="selector inline-block">
-                        <Input
-                            placeholder={"Filter..."}
-                            value={this.state.filterSearch}
-                            style={{width: "220px"}}
-                            onChange={this.handleFilterChange.bind(this)}
-                            addonAfter={<AntIcon type="search" />}
-                        />
-                    </div>
-                </div>
-                <div className={cnames("content-block")}>
-                    <VotingAccountsList
-                        type="committee"
-                        label="account.votes.add_committee_label"
-                        items={this.state.all_committee}
-                        validateAccount={this.validateAccount.bind(
-                            this,
-                            "committee"
-                        )}
-                        onAddItem={this.onAddItem.bind(this, "committee")}
-                        onRemoveItem={this.onRemoveItem.bind(this, "committee")}
-                        tabIndex={hasProxy ? -1 : 3}
-                        supported={
-                            this.state[
-                                hasProxy ? "proxy_committee" : "committee"
-                            ]
-                        }
-                        withSelector={false}
-                        active={globalObject.get("active_committee_members")}
-                        proxy={this.state.proxy_account_id}
-                        filterSearch={filterSearch}
-                    />
-                </div>
-                <JoinCommitteeModal
-                    visible={this.state.showCreateCommitteeModal}
+                <Committee
+                    all_committee={all_committee}
+                    proxy_committee={proxy_committee}
+                    committee={committee}
+                    proxy_account_id={proxy_account_id}
+                    onFilterChange={onFilterChange}
+                    validateAccountHandler={validateAccountHandler}
+                    addCommitteeHandler={addCommitteeHandler}
+                    removeCommitteeHandler={removeCommitteeHandler}
+                    hasProxy={hasProxy}
+                    globalObject={globalObject}
+                    filterSearch={filterSearch}
                     account={account}
-                    hideModal={this.showCommitteeModal.bind(this)}
                 />
             </Tab>
         );

--- a/app/components/Account/Voting/Committee.jsx
+++ b/app/components/Account/Voting/Committee.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import counterpart from "counterpart";
 import Translate from "react-translate-component";
 import JoinCommitteeModal from "../../Modal/JoinCommitteeModal";
 import VotingAccountsList from "../VotingAccountsList";
@@ -51,7 +52,9 @@ export default class Committee extends Component {
 
                     <div className="selector inline-block">
                         <Input
-                            placeholder={"Filter..."}
+                            placeholder={counterpart.translate(
+                                "explorer.witnesses.filter_by_name"
+                            )}
                             value={filterSearch}
                             style={{width: "220px"}}
                             onChange={onFilterChange}

--- a/app/components/Account/Voting/Committee.jsx
+++ b/app/components/Account/Voting/Committee.jsx
@@ -1,0 +1,86 @@
+import React, {Component} from "react";
+import Translate from "react-translate-component";
+import JoinCommitteeModal from "../../Modal/JoinCommitteeModal";
+import VotingAccountsList from "../VotingAccountsList";
+import cnames from "classnames";
+import {Input, Icon as AntIcon, Button} from "bitshares-ui-style-guide";
+
+export default class Committee extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showCreateCommitteeModal: false
+        };
+    }
+
+    render() {
+        const showCommitteeModal = () => {
+            console.log("show committee modal");
+            this.setState({
+                showCreateCommitteeModal: !this.state.showCreateCommitteeModal
+            });
+        };
+
+        const onFilterChange = this.props.onFilterChange;
+        const validateAccountHandler = this.props.validateAccountHandler;
+        const addCommitteeHandler = this.props.addCommitteeHandler;
+        const removeCommitteeHandler = this.props.removeCommitteeHandler;
+
+        const {showCreateCommitteeModal} = this.state;
+        const {
+            all_committee,
+            proxy_committee,
+            committee,
+            proxy_account_id,
+            hasProxy,
+            globalObject,
+            filterSearch,
+            account
+        } = this.props;
+        return (
+            <div>
+                <div className="header-selector">
+                    <div style={{float: "right"}}>
+                        <Button
+                            style={{marginRight: "5px"}}
+                            onClick={showCommitteeModal}
+                        >
+                            <Translate content="account.votes.join_committee" />
+                        </Button>
+                    </div>
+
+                    <div className="selector inline-block">
+                        <Input
+                            placeholder={"Filter..."}
+                            value={filterSearch}
+                            style={{width: "220px"}}
+                            onChange={onFilterChange}
+                            addonAfter={<AntIcon type="search" />}
+                        />
+                    </div>
+                </div>
+                <div className={cnames("content-block")}>
+                    <VotingAccountsList
+                        type="committee"
+                        label="account.votes.add_committee_label"
+                        items={all_committee}
+                        validateAccount={validateAccountHandler}
+                        onAddItem={addCommitteeHandler}
+                        onRemoveItem={removeCommitteeHandler}
+                        tabIndex={hasProxy ? -1 : 3}
+                        supported={hasProxy ? proxy_committee : committee}
+                        withSelector={false}
+                        active={globalObject.get("active_committee_members")}
+                        proxy={proxy_account_id}
+                        filterSearch={filterSearch}
+                    />
+                </div>
+                <JoinCommitteeModal
+                    visible={showCreateCommitteeModal}
+                    account={account}
+                    hideModal={showCommitteeModal}
+                />
+            </div>
+        );
+    }
+}

--- a/app/components/Account/Voting/Witnesses.jsx
+++ b/app/components/Account/Voting/Witnesses.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import counterpart from "counterpart";
 import Translate from "react-translate-component";
 import VotingAccountsList from "../VotingAccountsList";
 import cnames from "classnames";
@@ -51,7 +52,9 @@ export default class Witnesses extends Component {
 
                         <div className="selector inline-block">
                             <Input
-                                placeholder={"Filter..."}
+                                placeholder={counterpart.translate(
+                                    "explorer.witnesses.filter_by_name"
+                                )}
                                 value={filterSearch}
                                 style={{width: "220px"}}
                                 onChange={onFilterChange}

--- a/app/components/Account/Voting/Witnesses.jsx
+++ b/app/components/Account/Voting/Witnesses.jsx
@@ -1,0 +1,111 @@
+import React, {Component} from "react";
+import Immutable from "immutable";
+import Translate from "react-translate-component";
+import accountUtils from "common/account_utils";
+import {ChainStore, FetchChainObjects} from "bitsharesjs";
+import WorkersList from "../WorkersList";
+import VotingAccountsList from "../VotingAccountsList";
+import cnames from "classnames";
+import {Tabs, Tab} from "../../Utility/Tabs";
+import BindToChainState from "../../Utility/BindToChainState";
+import ChainTypes from "../../Utility/ChainTypes";
+import {Link} from "react-router-dom";
+import ApplicationApi from "api/ApplicationApi";
+import AccountSelector from "../AccountSelector";
+import Icon from "../../Icon/Icon";
+import AssetName from "../../Utility/AssetName";
+import counterpart from "counterpart";
+import {EquivalentValueComponent} from "../../Utility/EquivalentValueComponent";
+import FormattedAsset from "../../Utility/FormattedAsset";
+import SettingsStore from "stores/SettingsStore";
+import {
+    Switch,
+    Tooltip,
+    Row,
+    Col,
+    Radio,
+    Input,
+    Icon as AntIcon,
+    Button
+} from "bitshares-ui-style-guide";
+import AccountStore from "stores/AccountStore";
+import JoinWitnessesModal from "../../Modal/JoinWitnessesModal";
+
+export default class Witnesses extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showCreateWitnessModal: false
+        };
+    }
+
+    render() {
+        const showWitnessModal = () => {
+            this.setState({
+                showCreateWitnessModal: !this.state.showCreateWitnessModal
+            });
+        };
+
+        const onFilterChange = this.props.onFilterChange;
+        const validateAccountHandler = this.props.validateAccountHandler;
+        const addWitnessHandler = this.props.addWitnessHandler;
+        const removeWitnessHandler = this.props.removeWitnessHandler;
+
+        const {showCreateWitnessModal} = this.state;
+        const {
+            all_witnesses,
+            proxy_witnesses,
+            witnesses,
+            proxy_account_id,
+            hasProxy,
+            globalObject,
+            filterSearch,
+            account
+        } = this.props;
+        return (
+            <div>
+                <div className={cnames("content-block")}>
+                    <div className="header-selector">
+                        <div style={{float: "right"}}>
+                            <Button
+                                style={{marginRight: "5px"}}
+                                onClick={showWitnessModal}
+                            >
+                                <Translate content="account.votes.join_witnesses" />
+                            </Button>
+                        </div>
+
+                        <div className="selector inline-block">
+                            <Input
+                                placeholder={"Filter..."}
+                                value={filterSearch}
+                                style={{width: "220px"}}
+                                onChange={onFilterChange}
+                                addonAfter={<AntIcon type="search" />}
+                            />
+                        </div>
+                    </div>
+                    <VotingAccountsList
+                        type="witness"
+                        label="account.votes.add_witness_label"
+                        items={all_witnesses}
+                        validateAccount={validateAccountHandler}
+                        onAddItem={addWitnessHandler}
+                        onRemoveItem={removeWitnessHandler}
+                        tabIndex={hasProxy ? -1 : 2}
+                        supported={hasProxy ? proxy_witnesses : witnesses}
+                        withSelector={false}
+                        active={globalObject.get("active_witnesses")}
+                        proxy={proxy_account_id}
+                        filterSearch={filterSearch}
+                    />
+                </div>
+                <JoinWitnessesModal
+                    visible={showCreateWitnessModal}
+                    account={account}
+                    hideModal={showWitnessModal}
+                />
+            </div>
+        );
+    }
+}

--- a/app/components/Account/Voting/Witnesses.jsx
+++ b/app/components/Account/Voting/Witnesses.jsx
@@ -1,34 +1,8 @@
 import React, {Component} from "react";
-import Immutable from "immutable";
 import Translate from "react-translate-component";
-import accountUtils from "common/account_utils";
-import {ChainStore, FetchChainObjects} from "bitsharesjs";
-import WorkersList from "../WorkersList";
 import VotingAccountsList from "../VotingAccountsList";
 import cnames from "classnames";
-import {Tabs, Tab} from "../../Utility/Tabs";
-import BindToChainState from "../../Utility/BindToChainState";
-import ChainTypes from "../../Utility/ChainTypes";
-import {Link} from "react-router-dom";
-import ApplicationApi from "api/ApplicationApi";
-import AccountSelector from "../AccountSelector";
-import Icon from "../../Icon/Icon";
-import AssetName from "../../Utility/AssetName";
-import counterpart from "counterpart";
-import {EquivalentValueComponent} from "../../Utility/EquivalentValueComponent";
-import FormattedAsset from "../../Utility/FormattedAsset";
-import SettingsStore from "stores/SettingsStore";
-import {
-    Switch,
-    Tooltip,
-    Row,
-    Col,
-    Radio,
-    Input,
-    Icon as AntIcon,
-    Button
-} from "bitshares-ui-style-guide";
-import AccountStore from "stores/AccountStore";
+import {Input, Icon as AntIcon, Button} from "bitshares-ui-style-guide";
 import JoinWitnessesModal from "../../Modal/JoinWitnessesModal";
 
 export default class Witnesses extends Component {

--- a/app/components/Account/Voting/Workers.jsx
+++ b/app/components/Account/Voting/Workers.jsx
@@ -18,21 +18,32 @@ export default class Workers extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            workerTableIndex: props.workerTableIndex
+            newWorkersLength: null,
+            activeWorkersLength: null,
+            pollsLength: null,
+            expiredWorkersLength: null,
+            voteThreshold: null,
+            workerTableIndex: props.viewSettings.get("workerTableIndex", 1)
         };
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return (
+            ns.newWorkersLength !== this.state.newWorkersLength ||
+            ns.activeWorkersLength !== this.state.activeWorkersLength ||
+            ns.pollsLength !== this.state.pollsLength ||
+            ns.expiredWorkersLength !== this.state.expiredWorkersLength ||
+            ns.voteThreshold !== this.state.voteThreshold ||
+            np.workerTableIndex !== this.state.workerTableIndex
+        );
     }
 
     render() {
         const {
             vote_ids,
             proxy_vote_ids,
-            newWorkersLength,
-            activeWorkersLength,
-            pollsLength,
-            expiredWorkersLength,
             hideLegacy,
             preferredUnit,
-            voteThreshold,
             globalObject,
             totalBudget,
             workerBudget,
@@ -41,11 +52,17 @@ export default class Workers extends React.Component {
             filterSearch,
             onFilterChange,
             onChangeVotes,
-            getWorkerArray,
-            setWorkersLength
+            getWorkerArray
         } = this.props;
 
-        const {workerTableIndex} = this.state;
+        const {
+            workerTableIndex,
+            newWorkersLength,
+            activeWorkersLength,
+            pollsLength,
+            expiredWorkersLength,
+            voteThreshold
+        } = this.state;
 
         const setWorkerTableIndex = e => {
             this.setState({
@@ -152,7 +169,21 @@ export default class Workers extends React.Component {
                 <WorkersList
                     workerTableIndex={workerTableIndex}
                     preferredUnit={preferredUnit}
-                    setWorkersLength={setWorkersLength}
+                    setWorkersLength={(
+                        _newWorkersLength,
+                        _activeWorkersLength,
+                        _pollsLength,
+                        _expiredWorkersLength,
+                        _voteThreshold
+                    ) => {
+                        this.setState({
+                            newWorkersLength: _newWorkersLength,
+                            activeWorkersLength: _activeWorkersLength,
+                            pollsLength: _pollsLength,
+                            expiredWorkersLength: _expiredWorkersLength,
+                            voteThreshold: _voteThreshold
+                        });
+                    }}
                     workerBudget={workerBudget}
                     hideLegacyProposals={hideLegacyProposals}
                     hasProxy={hasProxy}

--- a/app/components/Account/Voting/Workers.jsx
+++ b/app/components/Account/Voting/Workers.jsx
@@ -1,0 +1,166 @@
+import React from "react";
+import Translate from "react-translate-component";
+import WorkersList from "../WorkersList";
+import {Link} from "react-router-dom";
+import AssetName from "../../Utility/AssetName";
+import counterpart from "counterpart";
+import {EquivalentValueComponent} from "../../Utility/EquivalentValueComponent";
+import FormattedAsset from "../../Utility/FormattedAsset";
+import {
+    Row,
+    Col,
+    Radio,
+    Input,
+    Icon as AntIcon
+} from "bitshares-ui-style-guide";
+
+export default class Workers extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            workerTableIndex: props.workerTableIndex
+        };
+    }
+
+    render() {
+        const {
+            vote_ids,
+            proxy_vote_ids,
+            newWorkersLength,
+            activeWorkersLength,
+            pollsLength,
+            expiredWorkersLength,
+            hideLegacy,
+            preferredUnit,
+            voteThreshold,
+            globalObject,
+            totalBudget,
+            workerBudget,
+            hideLegacyProposals,
+            hasProxy,
+            filterSearch,
+            onFilterChange,
+            onChangeVotes,
+            getWorkerArray,
+            setWorkersLength
+        } = this.props;
+
+        const {workerTableIndex} = this.state;
+
+        const setWorkerTableIndex = e => {
+            this.setState({
+                workerTableIndex: e.target.value
+            });
+        };
+
+        return (
+            <div>
+                <div className="header-selector">
+                    <div style={{float: "right"}}>
+                        <Link to="/create-worker" className="button primary">
+                            <Translate content="account.votes.create_worker" />
+                        </Link>
+                    </div>
+
+                    <div className="selector inline-block">
+                        <Input
+                            placeholder={"Filter..."}
+                            value={filterSearch}
+                            style={{width: "220px"}}
+                            onChange={onFilterChange}
+                            addonAfter={<AntIcon type="search" />}
+                        />
+                        <Radio.Group
+                            defaultValue={1}
+                            onChange={setWorkerTableIndex}
+                        >
+                            <Radio value={0}>
+                                {counterpart.translate("account.votes.new", {
+                                    count: newWorkersLength
+                                })}
+                            </Radio>
+
+                            <Radio value={1}>
+                                {counterpart.translate("account.votes.active", {
+                                    count: activeWorkersLength
+                                })}
+                            </Radio>
+
+                            {pollsLength ? (
+                                <Radio value={3}>
+                                    {counterpart.translate(
+                                        "account.votes.polls",
+                                        {count: pollsLength}
+                                    )}
+                                </Radio>
+                            ) : null}
+
+                            {expiredWorkersLength ? (
+                                <Radio value={2}>
+                                    <Translate content="account.votes.expired" />
+                                </Radio>
+                            ) : null}
+                        </Radio.Group>
+                    </div>
+
+                    {hideLegacy}
+                    <br />
+                    <br />
+                    <Row>
+                        <Col span={3}>
+                            <Translate content="account.votes.threshold" /> (
+                            <AssetName name={preferredUnit} />)
+                        </Col>
+                        <Col
+                            span={3}
+                            style={{
+                                marginLeft: "10px"
+                            }}
+                        >
+                            <FormattedAsset
+                                decimalOffset={4}
+                                hide_asset
+                                amount={voteThreshold}
+                                asset="1.3.0"
+                            />
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col span={3}>
+                            <Translate content="account.votes.total_budget" /> (
+                            <AssetName name={preferredUnit} />)
+                        </Col>
+                        <Col
+                            span={3}
+                            style={{
+                                marginLeft: "10px"
+                            }}
+                        >
+                            {globalObject ? (
+                                <EquivalentValueComponent
+                                    hide_asset
+                                    fromAsset="1.3.0"
+                                    toAsset={preferredUnit}
+                                    amount={totalBudget}
+                                />
+                            ) : null}
+                        </Col>
+                    </Row>
+                </div>
+                <WorkersList
+                    workerTableIndex={workerTableIndex}
+                    preferredUnit={preferredUnit}
+                    setWorkersLength={setWorkersLength}
+                    workerBudget={workerBudget}
+                    hideLegacyProposals={hideLegacyProposals}
+                    hasProxy={hasProxy}
+                    proxy_vote_ids={proxy_vote_ids}
+                    vote_ids={vote_ids}
+                    onChangeVotes={onChangeVotes}
+                    getWorkerArray={getWorkerArray}
+                    filterSearch={filterSearch}
+                />
+            </div>
+        );
+    }
+}

--- a/app/components/Account/Voting/Workers.jsx
+++ b/app/components/Account/Voting/Workers.jsx
@@ -64,7 +64,9 @@ export default class Workers extends React.Component {
 
                     <div className="selector inline-block">
                         <Input
-                            placeholder={"Filter..."}
+                            placeholder={counterpart.translate(
+                                "explorer.witnesses.filter_by_name"
+                            )}
                             value={filterSearch}
                             style={{width: "220px"}}
                             onChange={onFilterChange}

--- a/app/components/Account/WorkersList.jsx
+++ b/app/components/Account/WorkersList.jsx
@@ -668,13 +668,15 @@ class WorkerList extends React.Component {
                 };
             });
         // fixme: don't call setState in render
-        setWorkersLength(
-            newWorkers.length,
-            activeWorkers.length,
-            polls.length,
-            expiredWorkers.length,
-            voteThreshold
-        );
+        setTimeout(() => {
+            setWorkersLength(
+                newWorkers.length,
+                activeWorkers.length,
+                polls.length,
+                expiredWorkers.length,
+                voteThreshold
+            );
+        }, 0);
         const workers =
             workerTableIndex === 0
                 ? newWorkers

--- a/app/components/Modal/JoinCommitteeModal.jsx
+++ b/app/components/Modal/JoinCommitteeModal.jsx
@@ -52,6 +52,7 @@ class JoinCommitteeModal extends React.Component {
     }
 
     onClose() {
+        this.props.hideModal();
         this.setState(this.getInitialState(this.props));
     }
 


### PR DESCRIPTION
<h2>General</h2>
Closes #116 

Extracted all account voting tabs into separate components and made use of new Tabs from styleguide, added three routes as it was suggested in comments.
Checked tabs work against test and mainnet in different colors schemes, compared against previous implementation.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [x] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [x] Light
- [x] Midnight

_Please provide screenshots/licecap of your changes below_
![Screenshot from 2019-06-17 12-07-26](https://user-images.githubusercontent.com/16491260/59592346-8a69f600-90f8-11e9-99e1-aaf595a8cd7f.png)
![Screenshot from 2019-06-17 12-07-28](https://user-images.githubusercontent.com/16491260/59592347-8b028c80-90f8-11e9-9f7d-a13d56ec7563.png)
![Screenshot from 2019-06-17 12-07-30](https://user-images.githubusercontent.com/16491260/59592349-8b028c80-90f8-11e9-8b03-ab7c88ac7642.png)
