### PR TITLE
#122 Added saving of assets grouping state in view settings

### DIFF
--- a/app/components/Account/AccountOrders.jsx
+++ b/app/components/Account/AccountOrders.jsx
@@ -8,7 +8,6 @@ import SettingsStore from "stores/SettingsStore";
 import SettingsActions from "actions/SettingsActions";
 import marketUtils from "common/market_utils";
 import Translate from "react-translate-component";
-import PaginatedList from "../Utility/PaginatedList";
 import {Input, Icon, Table, Switch} from "bitshares-ui-style-guide";
 import AccountOrderRowDescription from "./AccountOrderRowDescription";
 import CollapsibleTable from "../Utility/CollapsibleTable";
@@ -29,7 +28,9 @@ class AccountOrders extends React.Component {
         this.state = {
             selectedOrders: [],
             filterValue: "",
-            areAssetsGrouped: false
+            areAssetsGrouped: props.viewSettings.get(
+                "accountOrdersGrouppedByAsset"
+            )
         };
     }
 
@@ -525,6 +526,9 @@ class AccountOrders extends React.Component {
         );
 
         let onGroupChange = (checked, evt) => {
+            SettingsActions.changeViewSetting({
+                accountOrdersGrouppedByAsset: checked
+            });
             this.setState({areAssetsGrouped: checked});
         };
 
@@ -566,7 +570,10 @@ class AccountOrders extends React.Component {
                         <div className="group-by">
                             <Translate content="account.group_by_asset" />
                             <span className="text">:</span>
-                            <Switch onChange={onGroupChange} />
+                            <Switch
+                                onChange={onGroupChange}
+                                checked={this.state.areAssetsGrouped}
+                            />
                         </div>
                     ) : null}
                 </div>
@@ -585,7 +592,8 @@ AccountOrders = connect(
         },
         getProps() {
             return {
-                marketDirections: SettingsStore.getState().marketDirections
+                marketDirections: SettingsStore.getState().marketDirections,
+                viewSettings: SettingsStore.getState().viewSettings
             };
         }
     }


### PR DESCRIPTION
<h2>General</h2>
Closes #122 

Added saving of grouping policy in view settings

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [x] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [x] Light
- [x] Midnight

_Please provide screenshots/licecap of your changes below_