### PR TITLE
Asset margins table refactoring

### DIFF
--- a/app/assets/locales/locale-de.json
+++ b/app/assets/locales/locale-de.json
@@ -749,7 +749,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Gebührenguthaben einfordern",
                 "claim_fees": "Gebühren einfordern",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -749,7 +749,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Claim fee pool balance",
                 "claim_fees": "Claim fees",

--- a/app/assets/locales/locale-es.json
+++ b/app/assets/locales/locale-es.json
@@ -749,7 +749,7 @@
                 },
                 "title": "Ofertas Colaterales"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Balance de la cuota de la reclamación",
                 "claim_fees": "Reclamar tarifas",

--- a/app/assets/locales/locale-fr.json
+++ b/app/assets/locales/locale-fr.json
@@ -743,7 +743,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Claim fee pool balance",
                 "claim_fees": "Claim fees",

--- a/app/assets/locales/locale-it.json
+++ b/app/assets/locales/locale-it.json
@@ -743,7 +743,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Claim fee pool balance",
                 "claim_fees": "Riscuoti commissioni",

--- a/app/assets/locales/locale-ja.json
+++ b/app/assets/locales/locale-ja.json
@@ -743,7 +743,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Claim fee pool balance",
                 "claim_fees": "手数料を請求",

--- a/app/assets/locales/locale-ko.json
+++ b/app/assets/locales/locale-ko.json
@@ -743,7 +743,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Claim fee pool balance",
                 "claim_fees": "Claim fees",

--- a/app/assets/locales/locale-ru.json
+++ b/app/assets/locales/locale-ru.json
@@ -749,7 +749,7 @@
                 },
                 "title": "Залоговые ставки"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Востребовать остаток пула комиссий",
                 "claim_fees": "Востребовать комиссии",

--- a/app/assets/locales/locale-tr.json
+++ b/app/assets/locales/locale-tr.json
@@ -743,7 +743,7 @@
                 },
                 "title": "Collateral Bids"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "Claim fee pool balance",
                 "claim_fees": "Ücretleri talep et",

--- a/app/assets/locales/locale-zh.json
+++ b/app/assets/locales/locale-zh.json
@@ -749,7 +749,7 @@
                 },
                 "title": "抵押物竞价"
             },
-            "cumulative": "Cumulative",
+            "cumulative": "Σ",
             "fee_pool": {
                 "claim_balance": "申领手续费池余额",
                 "claim_fees": "领取手续费",

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1475,7 +1475,14 @@ class Asset extends React.Component {
 
         let columns = [];
         let dataSource = [];
-
+        const cummulativeSuffix = cumulativeGrouping ? (
+            <span>
+                &nbsp;(
+                <Translate content="explorer.asset.cumulative" />)
+            </span>
+        ) : (
+            <span>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+        );
         columns = [
             {
                 key: "borrower",
@@ -1501,15 +1508,7 @@ class Asset extends React.Component {
                 title: (
                     <React.Fragment>
                         <Translate content="transaction.collateral" />
-                        {cumulativeGrouping ? (
-                            <span>
-                                &nbsp;(
-                                <Translate content="explorer.asset.cumulative" />
-                                )
-                            </span>
-                        ) : (
-                            ""
-                        )}
+                        {cummulativeSuffix}
                     </React.Fragment>
                 ),
                 dataIndex: "collateral",
@@ -1546,15 +1545,7 @@ class Asset extends React.Component {
                 title: (
                     <React.Fragment>
                         <Translate content="transaction.borrow_amount" />
-                        {cumulativeGrouping ? (
-                            <span>
-                                &nbsp;(
-                                <Translate content="explorer.asset.cumulative" />
-                                )
-                            </span>
-                        ) : (
-                            ""
-                        )}
+                        {cummulativeSuffix}
                     </React.Fragment>
                 ),
                 dataIndex: "debt",

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1481,7 +1481,7 @@ class Asset extends React.Component {
                 <Translate content="explorer.asset.cumulative" />)
             </span>
         ) : (
-            <span>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+            <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
         );
         columns = [
             {

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1483,6 +1483,50 @@ class Asset extends React.Component {
         ) : (
             <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
         );
+
+        let debt_cum = 0;
+        let coll_cum = 0;
+
+        this.state.callOrders.map(c => {
+            debt_cum += c.debt;
+            coll_cum += c.collateral;
+
+            dataSource.push({
+                borrower: c.borrower,
+                collateral: {
+                    amount: cumulativeGrouping ? coll_cum : c.collateral,
+                    asset: c.getCollateral().asset_id
+                },
+                debt: {
+                    amount: cumulativeGrouping ? debt_cum : c.debt,
+                    asset: c.amountToReceive().asset_id
+                },
+                call: c.call_price,
+                tcr: c.order.target_collateral_ratio,
+                cr: {
+                    ratio: c.getRatio(),
+                    status: c.getStatus()
+                }
+            });
+        });
+        const unitInfo = key => {
+            let item = dataSource[0][key];
+            return dataSource.length ? (
+                <span>
+                    <br />
+                    {item.base ? (
+                        this.formattedPrice(item, false, true)
+                    ) : (
+                        <FormattedAsset
+                            asset={item.asset}
+                            amount={item.amount}
+                            hide_amount={true}
+                        />
+                    )}
+                </span>
+            ) : null;
+        };
+
         columns = [
             {
                 key: "borrower",
@@ -1509,6 +1553,7 @@ class Asset extends React.Component {
                     <React.Fragment>
                         <Translate content="transaction.collateral" />
                         {cummulativeSuffix}
+                        {unitInfo("collateral")}
                     </React.Fragment>
                 ),
                 dataIndex: "collateral",
@@ -1534,6 +1579,7 @@ class Asset extends React.Component {
                                 <FormattedAsset
                                     amount={item.amount}
                                     asset={item.asset}
+                                    hide_asset={true}
                                 />
                             </span>
                         </Tooltip>
@@ -1546,6 +1592,7 @@ class Asset extends React.Component {
                     <React.Fragment>
                         <Translate content="transaction.borrow_amount" />
                         {cummulativeSuffix}
+                        {unitInfo("debt")}
                     </React.Fragment>
                 ),
                 dataIndex: "debt",
@@ -1571,6 +1618,7 @@ class Asset extends React.Component {
                                 <FormattedAsset
                                     amount={item.amount}
                                     asset={item.asset}
+                                    hide_asset={true}
                                 />
                             </span>
                         </Tooltip>
@@ -1579,18 +1627,15 @@ class Asset extends React.Component {
             },
             {
                 key: "call",
-                title: <Translate content="exchange.call" />,
+                title: (
+                    <span>
+                        <Translate content="exchange.call" />
+                        {unitInfo("call")}
+                    </span>
+                ),
                 dataIndex: "call",
                 render: item => {
-                    return (
-                        <FormattedPrice
-                            base_amount={item.base.amount}
-                            base_asset={item.base.asset_id}
-                            quote_amount={item.quote.amount}
-                            quote_asset={item.quote.asset_id}
-                            noPopOver
-                        />
-                    );
+                    return this.formattedPrice(item, true, false);
                 }
             },
             {
@@ -1633,32 +1678,6 @@ class Asset extends React.Component {
                 }
             }
         ];
-
-        let debt_cum = 0;
-        let coll_cum = 0;
-
-        this.state.callOrders.map(c => {
-            debt_cum += c.debt;
-            coll_cum += c.collateral;
-
-            dataSource.push({
-                borrower: c.borrower,
-                collateral: {
-                    amount: cumulativeGrouping ? coll_cum : c.collateral,
-                    asset: c.getCollateral().asset_id
-                },
-                debt: {
-                    amount: cumulativeGrouping ? debt_cum : c.debt,
-                    asset: c.amountToReceive().asset_id
-                },
-                call: c.call_price,
-                tcr: c.order.target_collateral_ratio,
-                cr: {
-                    ratio: c.getRatio(),
-                    status: c.getStatus()
-                }
-            });
-        });
 
         return (
             <Table

--- a/app/components/Utility/FormattedAsset.jsx
+++ b/app/components/Utility/FormattedAsset.jsx
@@ -174,7 +174,7 @@ class FormattedAsset extends React.Component {
                         </span>
                     ) : (
                         <span className="currency">
-                            &nbsp;
+                            {!hide_amount ? <span>&nbsp;</span> : null}
                             <AssetName
                                 noTip={this.props.noTip}
                                 noPrefix={this.props.noPrefix}


### PR DESCRIPTION
<h2>General</h2>
Closes #122 

Moved unit info to header of the table in margins section of asset info.
Changed symbol and fixed columns resizing appropriately.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [x] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [x] Light
- [x] Midnight

_Please provide screenshots/licecap of your changes below_
![Screenshot from 2019-06-18 14-07-02](https://user-images.githubusercontent.com/16491260/59677429-81e5ee00-91d2-11e9-9010-a1936df5270c.png)
![Screenshot from 2019-06-18 14-07-05](https://user-images.githubusercontent.com/16491260/59677430-827e8480-91d2-11e9-8336-a7616e399d27.png)
![Screenshot from 2019-06-18 14-07-10](https://user-images.githubusercontent.com/16491260/59677432-827e8480-91d2-11e9-9a7d-54ce27f33f6b.png)
![Screenshot from 2019-06-18 14-07-53](https://user-images.githubusercontent.com/16491260/59677433-83171b00-91d2-11e9-85fc-26c99e970f74.png)
