### PR TITLE
#140 Fixed open orders toolbar style …

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -190,6 +190,7 @@
         "quote": "Quote",
         "recent": "Recent activity",
         "reset_orders": "Reset",
+        "cancel_orders": "Cancel orders",
         "restore": "Restore",
         "search": "Search for an account",
         "see_open": "See open orders",

--- a/app/assets/stylesheets/components/_account.scss
+++ b/app/assets/stylesheets/components/_account.scss
@@ -263,12 +263,22 @@ div.header-selector {
         border-right: 0px;
     }
     > .group-by {
-        float: right;
-        line-height: 32px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
 
-        .text {
+    > .filter-block {
+        float: left;
+        display: flex;
+        align-items: center;
+        > .filter {
             margin-right: 10px;
         }
+    }
+
+    > .action-buttons {
+        float: right;
     }
 }
 

--- a/app/components/Account/AccountOrders.jsx
+++ b/app/components/Account/AccountOrders.jsx
@@ -8,7 +8,7 @@ import SettingsStore from "stores/SettingsStore";
 import SettingsActions from "actions/SettingsActions";
 import marketUtils from "common/market_utils";
 import Translate from "react-translate-component";
-import {Input, Icon, Table, Switch} from "bitshares-ui-style-guide";
+import {Input, Icon, Table, Switch, Button} from "bitshares-ui-style-guide";
 import AccountOrderRowDescription from "./AccountOrderRowDescription";
 import CollapsibleTable from "../Utility/CollapsibleTable";
 import {groupBy, sumBy, meanBy} from "lodash-es";
@@ -537,44 +537,50 @@ class AccountOrders extends React.Component {
                 className="grid-content no-overflow no-padding"
                 style={{paddingBottom: 15}}
             >
-                <div className="header-selector">
+                <div
+                    className="header-selector"
+                    style={{display: "inline-block", width: "100%"}}
+                >
                     {orders && ordersCount ? (
-                        <div className="filter inline-block">
-                            <Input
-                                type="text"
-                                placeholder={counterpart.translate(
-                                    "account.filter_orders"
-                                )}
-                                onChange={this.setFilterValue.bind(this)}
-                                addonAfter={<Icon type="search" />}
-                            />
+                        <div className="filter-block">
+                            <div className="filter">
+                                <Input
+                                    type="text"
+                                    placeholder={counterpart.translate(
+                                        "account.filter_orders"
+                                    )}
+                                    onChange={this.setFilterValue.bind(this)}
+                                    addonAfter={<Icon type="search" />}
+                                />
+                            </div>
+                            <div className="group-by">
+                                <Switch
+                                    onChange={onGroupChange}
+                                    checked={this.state.areAssetsGrouped}
+                                />
+                                &nbsp;&nbsp;
+                                <Translate content="account.group_by_asset" />
+                            </div>
                         </div>
                     ) : null}
                     {selectedOrders.length ? (
-                        <button
-                            className="button"
-                            onClick={this.resetSelected.bind(this)}
-                        >
-                            <Translate content="account.reset_orders" />
-                        </button>
-                    ) : null}
-                    {selectedOrders.length ? (
-                        <button
-                            className="button"
-                            onClick={this.cancelSelected.bind(this)}
-                        >
-                            <Translate content="account.submit_orders" />
-                        </button>
-                    ) : null}
-                    {orders && ordersCount ? (
-                        <div className="group-by">
-                            <Translate content="account.group_by_asset" />
-                            <span className="text">:</span>
-                            <Switch
-                                onChange={onGroupChange}
-                                checked={this.state.areAssetsGrouped}
-                            />
-                        </div>
+                        <span className="action-buttons">
+                            <Button
+                                key="submit"
+                                type="primary"
+                                onClick={this.cancelSelected.bind(this)}
+                            >
+                                <Translate content="account.submit_orders" />
+                            </Button>
+                            &nbsp;
+                            <Button
+                                key="cancel"
+                                type="secondary"
+                                onClick={this.resetSelected.bind(this)}
+                            >
+                                <Translate content="account.reset_orders" />
+                            </Button>
+                        </span>
                     ) : null}
                 </div>
 

--- a/app/components/Account/AccountOrders.jsx
+++ b/app/components/Account/AccountOrders.jsx
@@ -570,7 +570,7 @@ class AccountOrders extends React.Component {
                                 type="primary"
                                 onClick={this.cancelSelected.bind(this)}
                             >
-                                <Translate content="account.submit_orders" />
+                                <Translate content="account.cancel_orders" />
                             </Button>
                             &nbsp;
                             <Button


### PR DESCRIPTION
to meet a common styling and items alignment over an application.

<h2>General</h2>
Closes #140

Moved group by checkbox left and used style-guide buttons for submit and cancel and aligned them on the right side, as it is done in all over the other views in app.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [x] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [x] Light
- [x] Midnight

_Please provide screenshots/licecap of your changes below_
![image](https://user-images.githubusercontent.com/16491260/60769198-8157bd80-a0d5-11e9-8a08-3d788220bd7c.png)
