### PR TITLE
Fixed the issue with restore/import submenu

### DIFF
--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -133,6 +133,15 @@ class Header extends React.Component {
         document.body.removeEventListener("click", this.onBodyClick);
     }
 
+    componentWillReceiveProps(np) {
+        if (
+            np.passwordLogin !== this.props.passwordLogin &&
+            this.state.active.includes("/settings/")
+        ) {
+            this.props.history.push("/settings/general");
+        }
+    }
+
     shouldComponentUpdate(nextProps, nextState) {
         return (
             nextProps.myActiveAccounts !== this.props.myActiveAccounts ||
@@ -945,20 +954,22 @@ class Header extends React.Component {
                                 component="div"
                                 className="table-cell"
                             />
+                        </li>,
+                        <li
+                            key={"settings.restore"}
+                            onClick={this._onNavigate.bind(
+                                this,
+                                "/settings/restore"
+                            )}
+                        >
+                            <Translate
+                                content="settings.restore"
+                                component="div"
+                                className="table-cell"
+                            />
                         </li>
                     ]}
-                    <li
-                        onClick={this._onNavigate.bind(
-                            this,
-                            "/settings/restore"
-                        )}
-                    >
-                        <Translate
-                            content="settings.restore"
-                            component="div"
-                            className="table-cell"
-                        />
-                    </li>
+
                     <li
                         onClick={this._onNavigate.bind(
                             this,

--- a/app/components/Settings/Settings.jsx
+++ b/app/components/Settings/Settings.jsx
@@ -148,7 +148,7 @@ class Settings extends React.Component {
         menuEntries.push("accounts");
         if (!props.settings.get("passwordLogin")) menuEntries.push("password");
         if (!props.settings.get("passwordLogin")) menuEntries.push("backup");
-        menuEntries.push("restore");
+        if (!props.settings.get("passwordLogin")) menuEntries.push("restore");
         menuEntries.push("access");
 
         if (getFaucet().show) menuEntries.push("faucet_address");

--- a/app/components/Settings/Settings.jsx
+++ b/app/components/Settings/Settings.jsx
@@ -148,7 +148,7 @@ class Settings extends React.Component {
         menuEntries.push("accounts");
         if (!props.settings.get("passwordLogin")) menuEntries.push("password");
         if (!props.settings.get("passwordLogin")) menuEntries.push("backup");
-        if (!props.settings.get("passwordLogin")) menuEntries.push("restore");
+        menuEntries.push("restore");
         menuEntries.push("access");
 
         if (getFaucet().show) menuEntries.push("faucet_address");


### PR DESCRIPTION
<h2>General</h2>
Closes #166 
The issue was not the absence of translation, but the fact that Global Settings opened when you clicked on the Restore/Import menu item. This is now fixed. But Restore/Import menu item should probably only appear in Local Wallet Mode. Now in Cloud Wallet Mode this menu item displays only    in the mobile version.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [ ] Check for unused code
- [ ] No unrelated changes are included
- [ ] None of the changed files are reformatting only
- [ ] Code is self explanatory or documented
- [ ] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [ ] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_