### PR TITLE
#3040 adapt error messages to new json rpc of bitshares core 3.2.0

### DIFF
--- a/app/actions/TransactionConfirmActions.js
+++ b/app/actions/TransactionConfirmActions.js
@@ -53,7 +53,6 @@ class TransactionConfirmActions {
                     } catch (e) {
                         console.log(e);
                     }
-                    console.log("data", data);
                     dispatch({
                         broadcast: false,
                         broadcasting: false,

--- a/app/actions/TransactionConfirmActions.js
+++ b/app/actions/TransactionConfirmActions.js
@@ -46,11 +46,21 @@ class TransactionConfirmActions {
                     // longer messages are remote API exceptions (use the 1st line)
                     let splitError = error.message.split("\n");
                     let message = splitError[0];
+                    let code = splitError[2];
+                    let data;
+                    try {
+                        data = JSON.parse(splitError[3]);
+                    } catch (e) {
+                        console.log(e);
+                    }
+                    console.log("data", data);
                     dispatch({
                         broadcast: false,
                         broadcasting: false,
                         error: message,
-                        closed: false
+                        closed: false,
+                        error_code: code,
+                        error_data: data
                     });
                     if (reject) reject();
                 });

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -2355,6 +2355,7 @@
         "fund_pool": "funded %(asset)s fee pool with",
         "funding_account": "Funding account",
         "global_parameters_update": "Updated global parameters",
+        "hide": "Hide",
         "inputs": "Inputs",
         "market_fee": "Market fee",
         "max_market_fee": "Maximum market fee",
@@ -2369,6 +2370,7 @@
         "seller": "Seller",
         "sent": "sent",
         "settlement_date": "Settlement date",
+        "show_more": "Show more",
         "to": "to",
         "transaction_confirmed": "Transaction confirmed",
         "trxTypes": {

--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -26,19 +26,28 @@ class TransactionConfirm extends React.Component {
         super(props);
 
         this.state = {
-            isModalVisible: false
+            isModalVisible: false,
+            isErrorDetailsVisible: false
         };
 
         this.onCloseClick = this.onCloseClick.bind(this);
 
         this.onConfirmClick = this.onConfirmClick.bind(this);
 
+        this.onShowDetailsClick = this.onShowDetailsClick.bind(this);
+
         this.onKeyUp = this.onKeyUp.bind(this);
     }
 
-    shouldComponentUpdate(nextProps) {
+    shouldComponentUpdate(nextProps, nextState) {
         if (!nextProps.transaction) {
             return false;
+        }
+
+        if (
+            nextState.isErrorDetailsVisible !== this.state.isErrorDetailsVisible
+        ) {
+            return true;
         }
 
         return !utils.are_equal_shallow(nextProps, this.props);
@@ -60,7 +69,8 @@ class TransactionConfirm extends React.Component {
 
     hideModal() {
         this.setState({
-            isModalVisible: false
+            isModalVisible: false,
+            isErrorDetailsVisible: false
         });
     }
 
@@ -96,6 +106,12 @@ class TransactionConfirm extends React.Component {
     onCloseClick(e) {
         e.preventDefault();
         TransactionConfirmActions.close(this.props.reject);
+    }
+
+    onShowDetailsClick() {
+        this.setState(state => {
+            return {isErrorDetailsVisible: !state.isErrorDetailsVisible};
+        });
     }
 
     onProposeClick() {
@@ -148,10 +164,10 @@ class TransactionConfirm extends React.Component {
 
     render() {
         let {broadcast, broadcasting} = this.props;
+        let {isErrorDetailsVisible} = this.state;
         if (!this.props.transaction || this.props.closed) {
             return null;
         }
-        let a = <a href="https:/google.com">MORE</a>;
         let button_group,
             footer,
             header,
@@ -171,7 +187,7 @@ class TransactionConfirm extends React.Component {
 
             error_message = this.props.error;
             error_code = this.props.error_code;
-            error_data = this.props.error_data;
+            error_data = JSON.stringify(this.props.error_data, null, " ");
             if (error_code) {
                 error_message = `${error_code} - ${error_message}`;
             }
@@ -180,7 +196,13 @@ class TransactionConfirm extends React.Component {
                     <div>
                         {error_message}
                         <br />
-                        <a>Show more</a>
+                        <a onClick={this.onShowDetailsClick}>
+                            {isErrorDetailsVisible
+                                ? counterpart.translate("transaction.hide")
+                                : counterpart.translate(
+                                      "transaction.show_more"
+                                  )}
+                        </a>
                     </div>
                 );
             }
@@ -255,6 +277,14 @@ class TransactionConfirm extends React.Component {
                                 description={`#${this.props.trx_id}@${
                                     this.props.trx_block_num
                                 }`}
+                            />
+                        ) : null}
+
+                        {isErrorDetailsVisible ? (
+                            <Alert
+                                type="error"
+                                style={{fontSize: "0.7rem"}}
+                                message={error_data}
                             />
                         ) : null}
 

--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -151,9 +151,13 @@ class TransactionConfirm extends React.Component {
         if (!this.props.transaction || this.props.closed) {
             return null;
         }
+        let a = <a href="https:/google.com">MORE</a>;
         let button_group,
             footer,
             header,
+            error_code,
+            error_data,
+            error_message,
             confirmButtonClass = "button";
         if (this.props.propose && !this.props.fee_paying_account)
             confirmButtonClass += " disabled";
@@ -164,6 +168,22 @@ class TransactionConfirm extends React.Component {
                       message: ""
                   })
                 : counterpart.translate("transaction.transaction_confirmed");
+
+            error_message = this.props.error;
+            error_code = this.props.error_code;
+            error_data = this.props.error_data;
+            if (error_code) {
+                error_message = `${error_code} - ${error_message}`;
+            }
+            if (error_data) {
+                error_message = (
+                    <div>
+                        {error_message}
+                        <br />
+                        <a>Show more</a>
+                    </div>
+                );
+            }
 
             footer = [
                 <Button key={"cancel"} onClick={this.onCloseClick}>
@@ -223,7 +243,7 @@ class TransactionConfirm extends React.Component {
                 >
                     <div className="grid-block vertical no-padding no-margin">
                         {this.props.error ? (
-                            <Alert type="error" message={this.props.error} />
+                            <Alert type="error" message={error_message} />
                         ) : null}
 
                         {this.props.included ? (

--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -185,9 +185,12 @@ class TransactionConfirm extends React.Component {
                   })
                 : counterpart.translate("transaction.transaction_confirmed");
 
-            error_message = this.props.error;
-            error_code = this.props.error_code;
-            error_data = JSON.stringify(this.props.error_data, null, " ");
+            ({error: error_message, error_code, error_data} = this.props);
+            error_data = (
+                <div>
+                    <pre>{JSON.stringify(error_data, null, 1)}</pre>
+                </div>
+            );
             if (error_code) {
                 error_message = `${error_code} - ${error_message}`;
             }
@@ -196,12 +199,15 @@ class TransactionConfirm extends React.Component {
                     <div>
                         {error_message}
                         <br />
-                        <a onClick={this.onShowDetailsClick}>
-                            {isErrorDetailsVisible
-                                ? counterpart.translate("transaction.hide")
-                                : counterpart.translate(
-                                      "transaction.show_more"
-                                  )}
+                        <a>
+                            <Translate
+                                onClick={this.onShowDetailsClick}
+                                content={
+                                    isErrorDetailsVisible
+                                        ? "transaction.hide"
+                                        : "transaction.show_more"
+                                }
+                            />
                         </a>
                     </div>
                 );


### PR DESCRIPTION
<h2>General</h2>
Closes #185 
I added the error code and error details in the Transaction Confirm dialog, if available. I haven't tested the new code with a node that uses the old version of the error, but I added the code in such a way as not to change the logic of displaying the old error. I tested the new code by executing several failed transactions. I also made a PR in bitsharesjs to add an error detail pass to the UI.

![TransactionConfirm1](https://user-images.githubusercontent.com/16491260/63772070-08a8fc80-c8e1-11e9-90b2-4cc403d8f7c3.png)

![TransactionConfirm2](https://user-images.githubusercontent.com/16491260/63772075-0b0b5680-c8e1-11e9-958d-ccb910309af9.png)


<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [ ] Check for unused code
- [ ] No unrelated changes are included
- [ ] None of the changed files are reformatting only
- [ ] Code is self explanatory or documented
- [ ] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [ ] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_